### PR TITLE
docs: remove notice tag

### DIFF
--- a/docs/v2/smart-contracts/BaseStrategy.md
+++ b/docs/v2/smart-contracts/BaseStrategy.md
@@ -8,7 +8,7 @@
   function apiVersion(
   ) public returns (string)
 ```
-@notice
+
  Used to track which version of `StrategyAPI` this Strategy
  implements.
 
@@ -41,7 +41,7 @@ This Strategy's name.
   function delegatedAssets(
   ) external returns (uint256)
 ```
-@notice
+
  The amount (priced in want) of the total assets managed by this strategy should not count
  towards Yearn's TVL calculations.
 @dev
@@ -75,7 +75,7 @@ This Strategy's name.
     address _keeper
   ) internal
 ```
-@notice
+
  Initializes the Strategy, this is called only once, when the
  contract is deployed.
 
@@ -97,7 +97,7 @@ can harvest and tend a strategy.
     address _strategist
   ) external
 ```
-@notice
+
  Used to change `strategist`.
 
  This may only be called by governance or the existing strategist.
@@ -114,7 +114,7 @@ can harvest and tend a strategy.
     address _keeper
   ) external
 ```
-@notice
+
  Used to change `keeper`.
 
  `keeper` is the only address that may call `tend()` or `harvest()`,
@@ -137,7 +137,7 @@ can harvest and tend a strategy.
     address _rewards
   ) external
 ```
-@notice
+
  Used to change `rewards`. EOA or smart contract which has the permission
  to pull rewards from the vault.
 
@@ -155,7 +155,7 @@ can harvest and tend a strategy.
     uint256 _delay
   ) external
 ```
-@notice
+
  Used to change `minReportDelay`. `minReportDelay` is the minimum number
  of blocks that should pass for `harvest()` to be called.
 
@@ -177,7 +177,7 @@ can harvest and tend a strategy.
     uint256 _delay
   ) external
 ```
-@notice
+
  Used to change `maxReportDelay`. `maxReportDelay` is the maximum number
  of blocks that should pass for `harvest()` to be called.
 
@@ -199,7 +199,7 @@ can harvest and tend a strategy.
     uint256 _profitFactor
   ) external
 ```
-@notice
+
  Used to change `profitFactor`. `profitFactor` is used to determine
  if it's worthwhile to harvest, given gas costs. (See `harvestTrigger()`
  for more details.)
@@ -219,7 +219,7 @@ can harvest and tend a strategy.
     uint256 _debtThreshold
   ) external
 ```
-@notice
+
  Sets how far the Strategy can go into loss without a harvest and report
  being required.
 
@@ -242,7 +242,7 @@ being required to report to the Vault.
     string _metadataURI
   ) external
 ```
-@notice
+
  Used to change `metadataURI`. `metadataURI` is used to store the URI
 of the file describing the strategy.
 
@@ -270,7 +270,7 @@ on protected functions in the Strategy.
     uint256 _amtInWei
   ) public returns (uint256)
 ```
-@notice
+
  Provide an accurate conversion from `_amtInWei` (denominated in wei)
  to `want` (using the native decimal characteristics of `want`).
 @dev
@@ -297,7 +297,7 @@ on protected functions in the Strategy.
   function estimatedTotalAssets(
   ) public returns (uint256)
 ```
-@notice
+
  Provide an accurate estimate for the total amount of assets
  (principle + return) that this Strategy is currently managing,
  denominated in terms of `want` tokens.
@@ -412,7 +412,7 @@ liquidate all of the Strategy's positions back to the Vault.
     uint256 callCostInWei
   ) public returns (bool)
 ```
-@notice
+
  Provide a signal to the keeper that `tend()` should be called. The
  keeper will provide the estimated gas cost that they would pay to call
  `tend()`, and this function should use that estimate to make a
@@ -442,7 +442,7 @@ liquidate all of the Strategy's positions back to the Vault.
   function tend(
   ) external
 ```
-@notice
+
  Adjust the Strategy's position. The purpose of tending isn't to
  realize gains, but to maximize yield by reinvesting any returns.
 
@@ -458,7 +458,7 @@ liquidate all of the Strategy's positions back to the Vault.
     uint256 callCostInWei
   ) public returns (bool)
 ```
-@notice
+
  Provide a signal to the keeper that `harvest()` should be called. The
  keeper will provide the estimated gas cost that they would pay to call
  `harvest()`, and this function should use that estimate to make a
@@ -500,7 +500,7 @@ liquidate all of the Strategy's positions back to the Vault.
   function harvest(
   ) external
 ```
-@notice
+
  Harvests the Strategy, recognizing any profits or losses and adjusting
  the Strategy's position.
 
@@ -524,7 +524,7 @@ liquidate all of the Strategy's positions back to the Vault.
     uint256 _amountNeeded
   ) external returns (uint256 _loss)
 ```
-@notice
+
  Withdraws `_amountNeeded` to `vault`.
 
  This may only be called by the Vault.
@@ -556,7 +556,7 @@ value.
     address _newStrategy
   ) external
 ```
-@notice
+
  Transfers all `want` from this Strategy to `_newStrategy`.
 
  This may only be called by the Vault.
@@ -577,7 +577,7 @@ interacted with the vault before.
   function setEmergencyExit(
   ) external
 ```
-@notice
+
  Activates emergency exit. Once activated, the Strategy will exit its
  position upon the next harvest, depositing all funds into the Vault as
  quickly as is reasonable given on-chain conditions.
@@ -618,7 +618,7 @@ Example:
     address _token
   ) external
 ```
-@notice
+
  Removes tokens from this Strategy that are not the type of tokens
  managed by this Strategy. This may be used in case of accidentally
  sending the wrong kind of token to this Strategy.

--- a/docs/v2/smart-contracts/BaseWrapper.md
+++ b/docs/v2/smart-contracts/BaseWrapper.md
@@ -18,7 +18,7 @@
     address _registry
   ) external
 ```
-@notice
+
  Used to update the yearn registry.
 
 
@@ -32,7 +32,7 @@
   function bestVault(
   ) public returns (contract VaultAPI)
 ```
-@notice
+
  Used to get the most revent vault for the token using the registry.
 
 
@@ -46,7 +46,7 @@
   function allVaults(
   ) public returns (contract VaultAPI[])
 ```
-@notice
+
  Used to get all vaults from the registery for the token
 
 
@@ -69,7 +69,7 @@
   function totalVaultBalance(
   ) public returns (uint256 balance)
 ```
-@notice
+
  Used to get the balance of an account accross all the vaults for a token.
  @dev will be used to get the wrapper balance using totalVaultBalance(address(this)).
  @param account The address of the account.
@@ -82,7 +82,7 @@
   function totalAssets(
   ) public returns (uint256 assets)
 ```
-@notice
+
  Used to get the TVL on the underlying vaults.
  @return assets the sum of all the assets managed by the underlying vaults.
 

--- a/docs/v2/smart-contracts/registry.md
+++ b/docs/v2/smart-contracts/registry.md
@@ -16,7 +16,7 @@ function setGovernance(address)
 ```
 
 
-@notice Starts the 1st phase of the governance transfer.    
+Starts the 1st phase of the governance transfer.    
 
 
 *Throws if the caller is not current governance.*
@@ -39,7 +39,7 @@ function acceptGovernance()
 ```
 
 
-@notice Completes the 2nd phase of the governance transfer.    
+Completes the 2nd phase of the governance transfer.    
 
 
 *Throws if the caller is not the pending caller. Emits a `NewGovernance` event.*
@@ -56,7 +56,7 @@ function latestRelease()
 ```
 
 
-@notice Returns the api version of the latest release.    
+Returns the api version of the latest release.    
 
 
 *Throws if no releases are registered yet.*
@@ -79,7 +79,7 @@ function latestVault(address)
 ```
 
 
-@notice Returns the latest deployed vault for the given token.    
+Returns the latest deployed vault for the given token.    
 
 
 *Throws if no vaults are endorsed yet for the given token.*
@@ -108,7 +108,7 @@ function newRelease(address)
 ```
 
 
-@notice Add a previously deployed Vault as the template contract for the latest release, to be used by further &#34;forwarder-style&#34; delegatecall proxy contracts that can be deployed from the registry throw other methods (to save gas).    
+Add a previously deployed Vault as the template contract for the latest release, to be used by further &#34;forwarder-style&#34; delegatecall proxy contracts that can be deployed from the registry throw other methods (to save gas).    
 
 
 *Throws if caller isn&#39;t `self.governance`. Throws if `vault`&#39;s governance isn&#39;t `self.governance`. Throws if the api version is the same as the previous release. Emits a `NewVault` event.*
@@ -131,7 +131,7 @@ function newVault(address,address,address,string,string)
 ```
 
 
-@notice Create a new vault for the given token using the latest release in the registry, as a simple &#34;forwarder-style&#34; delegatecall proxy to the latest release. Also adds the new vault to the list of &#34;endorsed&#34; vaults for that token.    
+Create a new vault for the given token using the latest release in the registry, as a simple &#34;forwarder-style&#34; delegatecall proxy to the latest release. Also adds the new vault to the list of &#34;endorsed&#34; vaults for that token.    
 
 
 *`governance` is set in the new vault as `self.governance`, with no ability to override. Throws if caller isn&#39;t `self.governance`. Throws if no releases are registered yet. Throws if there already is a registered vault for the given token with the latest api version. Emits a `NewVault` event.*
@@ -197,7 +197,7 @@ function newExperimentalVault(address,address,address,address,string,string)
 ```
 
 
-@notice Create a new vault for the given token using the latest release in the registry, as a simple &#34;forwarder-style&#34; delegatecall proxy to the latest release. Does not add the new vault to the list of &#34;endorsed&#34; vaults for that token.    
+Create a new vault for the given token using the latest release in the registry, as a simple &#34;forwarder-style&#34; delegatecall proxy to the latest release. Does not add the new vault to the list of &#34;endorsed&#34; vaults for that token.    
 
 
 *Throws if no releases are registered yet. Emits a `NewExperimentalVault` event.*
@@ -265,7 +265,7 @@ function endorseVault(address)
 ```
 
 
-@notice Adds an existing vault to the list of &#34;endorsed&#34; vaults for that token.    
+Adds an existing vault to the list of &#34;endorsed&#34; vaults for that token.    
 
 
 *`governance` is set in the new vault as `self.governance`, with no ability to override. Throws if caller isn&#39;t `self.governance`. Throws if `vault`&#39;s governance isn&#39;t `self.governance`. Throws if no releases are registered yet. Throws if `vault`&#39;s api version does not match latest release. Throws if there already is a deployment for the vault&#39;s token with the latest api version. Emits a `NewVault` event.*
@@ -311,7 +311,7 @@ function setBanksy(address)
 ```
 
 
-@notice Set the ability of a particular tagger to tag current vaults.    
+Set the ability of a particular tagger to tag current vaults.    
 
 
 *Throws if caller is not `self.governance`.*
@@ -357,7 +357,7 @@ function tagVault(address,string)
 ```
 
 
-@notice Tag a Vault with a message.    
+Tag a Vault with a message.    
 
 
 *Throws if caller is not `self.governance` or an approved tagger. Emits a `VaultTagged` event.*

--- a/docs/v2/smart-contracts/vault.md
+++ b/docs/v2/smart-contracts/vault.md
@@ -20,7 +20,7 @@ function initialize(address,address,address,string,string)
 ```
 
 
-@notice Initializes the Vault, this is called only once, when the contract is deployed. The performance fee is set to 10% of yield, per Strategy. The management fee is set to 2%, per year. The initial deposit limit is set to 0 (deposits disabled); it must be updated after initialization.    
+Initializes the Vault, this is called only once, when the contract is deployed. The performance fee is set to 10% of yield, per Strategy. The management fee is set to 2%, per year. The initial deposit limit is set to 0 (deposits disabled); it must be updated after initialization.    
 
 
 *If `nameOverride` is not specified, the name will be &#39;yearn&#39; combined with the name of `token`. If `symbolOverride` is not specified, the symbol will be &#39;yv&#39; combined with the symbol of `token`. The token used by the vault should not change balances outside transfers and it must transfer the exact amount requested. Fee on transfer and rebasing are not supported.*
@@ -103,7 +103,7 @@ function apiVersion()
 ```
 
 
-@notice Used to track the deployed version of this contract. In practice you can use this version number to compare with Yearn&#39;s GitHub and determine which version of the source matches this deployed contract.    
+Used to track the deployed version of this contract. In practice you can use this version number to compare with Yearn&#39;s GitHub and determine which version of the source matches this deployed contract.    
 
 
 *All strategies must have an `apiVersion()` that matches the Vault&#39;s `API_VERSION`.*
@@ -126,7 +126,7 @@ function setName(string)
 ```
 
 
-@notice Used to change the value of `name`. This may only be called by governance.    
+Used to change the value of `name`. This may only be called by governance.    
 
 
 
@@ -147,7 +147,7 @@ function setSymbol(string)
 ```
 
 
-@notice Used to change the value of `symbol`. This may only be called by governance.    
+Used to change the value of `symbol`. This may only be called by governance.    
 
 
 
@@ -168,7 +168,7 @@ function setGovernance(address)
 ```
 
 
-@notice Nominate a new address to use as governance. The change does not go into effect immediately. This function sets a pending change, and the governance address is not updated until the proposed governance address has accepted the responsibility. This may only be called by the current governance address.    
+Nominate a new address to use as governance. The change does not go into effect immediately. This function sets a pending change, and the governance address is not updated until the proposed governance address has accepted the responsibility. This may only be called by the current governance address.    
 
 
 
@@ -189,7 +189,7 @@ function acceptGovernance()
 ```
 
 
-@notice Once a new governance address has been proposed using setGovernance(), this function may be called by the proposed address to accept the responsibility of taking over governance for this contract. This may only be called by the proposed governance address.    
+Once a new governance address has been proposed using setGovernance(), this function may be called by the proposed address to accept the responsibility of taking over governance for this contract. This may only be called by the proposed governance address.    
 
 
 *setGovernance() should be called by the existing governance address, prior to calling this function.*
@@ -206,7 +206,7 @@ function setManagement(address)
 ```
 
 
-@notice Changes the management address. Management is able to make some investment decisions adjusting parameters. This may only be called by governance.    
+Changes the management address. Management is able to make some investment decisions adjusting parameters. This may only be called by governance.    
 
 
 
@@ -227,7 +227,7 @@ function setRewards(address)
 ```
 
 
-@notice Changes the rewards address. Any distributed rewards will cease flowing to the old address and begin flowing to this address once the change is in effect. This will not change any Strategy reports in progress, only new reports made after this change goes into effect. This may only be called by governance.    
+Changes the rewards address. Any distributed rewards will cease flowing to the old address and begin flowing to this address once the change is in effect. This will not change any Strategy reports in progress, only new reports made after this change goes into effect. This may only be called by governance.    
 
 
 
@@ -248,7 +248,7 @@ function setLockedProfitDegradation(uint256)
 ```
 
 
-@notice Changes the locked profit degradation.    
+Changes the locked profit degradation.    
 
 
 
@@ -269,7 +269,7 @@ function setDepositLimit(uint256)
 ```
 
 
-@notice Changes the maximum amount of tokens that can be deposited in this Vault. Note, this is not how much may be deposited by a single depositor, but the maximum amount that may be deposited across all depositors. This may only be called by governance.    
+Changes the maximum amount of tokens that can be deposited in this Vault. Note, this is not how much may be deposited by a single depositor, but the maximum amount that may be deposited across all depositors. This may only be called by governance.    
 
 
 
@@ -290,7 +290,7 @@ function setPerformanceFee(uint256)
 ```
 
 
-@notice Used to change the value of `performanceFee`. Should set this value below the maximum strategist performance fee. This may only be called by governance.    
+Used to change the value of `performanceFee`. Should set this value below the maximum strategist performance fee. This may only be called by governance.    
 
 
 
@@ -311,7 +311,7 @@ function setManagementFee(uint256)
 ```
 
 
-@notice Used to change the value of `managementFee`. This may only be called by governance.    
+Used to change the value of `managementFee`. This may only be called by governance.    
 
 
 
@@ -332,7 +332,7 @@ function setGuardian(address)
 ```
 
 
-@notice Used to change the address of `guardian`. This may only be called by governance or the existing guardian.    
+Used to change the address of `guardian`. This may only be called by governance or the existing guardian.    
 
 
 
@@ -353,7 +353,7 @@ function setEmergencyShutdown(bool)
 ```
 
 
-@notice Activates or deactivates Vault mode where all Strategies go into full withdrawal. During Emergency Shutdown: 1. No Users may deposit into the Vault (but may withdraw as usual.) 2. Governance may not add new Strategies. 3. Each Strategy must pay back their debt as quickly as reasonable to minimally affect their position. 4. Only Governance may undo Emergency Shutdown. See contract level note for further details. This may only be called by governance or the guardian.    
+Activates or deactivates Vault mode where all Strategies go into full withdrawal. During Emergency Shutdown: 1. No Users may deposit into the Vault (but may withdraw as usual.) 2. Governance may not add new Strategies. 3. Each Strategy must pay back their debt as quickly as reasonable to minimally affect their position. 4. Only Governance may undo Emergency Shutdown. See contract level note for further details. This may only be called by governance or the guardian.    
 
 
 
@@ -374,7 +374,7 @@ function setWithdrawalQueue(address[20])
 ```
 
 
-@notice Updates the withdrawalQueue to match the addresses and order specified by `queue`. There can be fewer strategies than the maximum, as well as fewer than the total number of strategies active in the vault. `withdrawalQueue` will be updated in a gas-efficient manner, assuming the input is well- ordered with 0x0 only at the end. This may only be called by governance or management.    
+Updates the withdrawalQueue to match the addresses and order specified by `queue`. There can be fewer strategies than the maximum, as well as fewer than the total number of strategies active in the vault. `withdrawalQueue` will be updated in a gas-efficient manner, assuming the input is well- ordered with 0x0 only at the end. This may only be called by governance or management.    
 
 
 *This is order sensitive, specify the addresses in the order in which funds should be withdrawn (so `queue`[0] is the first Strategy withdrawn from, `queue`[1] is the second, etc.) This means that the least impactful Strategy (the Strategy that will have its core positions impacted the least by having funds removed) should be at `queue`[0], then the next least impactful at `queue`[1], and so on.*
@@ -397,7 +397,7 @@ function transfer(address,uint256)
 ```
 
 
-@notice Transfers shares from the caller&#39;s address to `receiver`. This function will always return true, unless the user is attempting to transfer shares to this contract&#39;s address, or to 0x0.    
+Transfers shares from the caller&#39;s address to `receiver`. This function will always return true, unless the user is attempting to transfer shares to this contract&#39;s address, or to 0x0.    
 
 
 
@@ -425,7 +425,7 @@ function transferFrom(address,address,uint256)
 ```
 
 
-@notice Transfers `amount` shares from `sender` to `receiver`. This operation will always return true, unless the user is attempting to transfer shares to this contract&#39;s address, or to 0x0. Unless the caller has given this contract unlimited approval, transfering shares will decrement the caller&#39;s `allowance` by `amount`.    
+Transfers `amount` shares from `sender` to `receiver`. This operation will always return true, unless the user is attempting to transfer shares to this contract&#39;s address, or to 0x0. Unless the caller has given this contract unlimited approval, transfering shares will decrement the caller&#39;s `allowance` by `amount`.    
 
 
 
@@ -520,7 +520,7 @@ function permit(address,address,uint256,uint256,bytes)
 ```
 
 
-@notice Approves spender by owner&#39;s signature to expend owner&#39;s tokens. See https://eips.ethereum.org/EIPS/eip-2612.    
+Approves spender by owner&#39;s signature to expend owner&#39;s tokens. See https://eips.ethereum.org/EIPS/eip-2612.    
 
 
 
@@ -551,7 +551,7 @@ function totalAssets()
 ```
 
 
-@notice Returns the total quantity of all assets under control of this Vault, whether they&#39;re loaned out to a Strategy, or currently held in the Vault.    
+Returns the total quantity of all assets under control of this Vault, whether they&#39;re loaned out to a Strategy, or currently held in the Vault.    
 
 
 
@@ -572,7 +572,7 @@ function deposit()
 ```
 
 
-@notice Deposits `_amount` `token`, issuing shares to `recipient`. If the Vault is in Emergency Shutdown, deposits will not be accepted and this call will fail.    
+Deposits `_amount` `token`, issuing shares to `recipient`. If the Vault is in Emergency Shutdown, deposits will not be accepted and this call will fail.    
 
 
 *Measuring quantity of shares to issues is based on the total outstanding debt that this contract has (&#34;expected value&#34;) instead of the total balance sheet it has (&#34;estimated value&#34;) has important security considerations, and is done intentionally. If this value were measured against external systems, it could be purposely manipulated by an attacker to withdraw more assets than they otherwise should be able to claim by redeeming their shares. On deposit, this means that shares are issued against the total amount that the deposited capital can be given in service of the debt that Strategies assume. If that number were to be lower than the &#34;expected value&#34; at some future point, depositing shares via this method could entitle the depositor to *less* than the deposited value once the &#34;realized value&#34; is updated from further reports by the Strategies to the Vaults. Care should be taken by integrators to account for this discrepancy, by using the view-only methods of this contract (both off-chain and on-chain) to determine if depositing into the Vault is a &#34;good idea&#34;.*
@@ -658,7 +658,7 @@ function maxAvailableShares()
 ```
 
 
-@notice Determines the maximum quantity of shares this Vault can facilitate a withdrawal for, factoring in assets currently residing in the Vault, as well as those deployed to strategies on the Vault&#39;s balance sheet.    
+Determines the maximum quantity of shares this Vault can facilitate a withdrawal for, factoring in assets currently residing in the Vault, as well as those deployed to strategies on the Vault&#39;s balance sheet.    
 
 
 *Regarding how shares are calculated, see dev note on `deposit`. If you want to calculated the maximum a user could withdraw up to, you want to use this function. Note that the amount provided by this function is the theoretical maximum possible from withdrawing, the real amount depends on the realized losses incurred during withdrawal.*
@@ -681,7 +681,7 @@ function withdraw()
 ```
 
 
-@notice Withdraws the calling account&#39;s tokens from this Vault, redeeming amount `_shares` for an appropriate amount of tokens. See note on `setWithdrawalQueue` for further details of withdrawal ordering and behavior.    
+Withdraws the calling account&#39;s tokens from this Vault, redeeming amount `_shares` for an appropriate amount of tokens. See note on `setWithdrawalQueue` for further details of withdrawal ordering and behavior.    
 
 
 *Measuring the value of shares is based on the total outstanding debt that this contract has (&#34;expected value&#34;) instead of the total balance sheet it has (&#34;estimated value&#34;) has important security considerations, and is done intentionally. If this value were measured against external systems, it could be purposely manipulated by an attacker to withdraw more assets than they otherwise should be able to claim by redeeming their shares. On withdrawal, this means that shares are redeemed against the total amount that the deposited capital had &#34;realized&#34; since the point it was deposited, up until the point it was withdrawn. If that number were to be higher than the &#34;expected value&#34; at some future point, withdrawing shares via this method could entitle the depositor to *more* than the expected value once the &#34;realized value&#34; is updated from further reports by the Strategies to the Vaults. Under exceptional scenarios, this could cause earlier withdrawals to earn &#34;more&#34; of the underlying assets than Users might otherwise be entitled to, if the Vault&#39;s estimated value were otherwise measured through external means, accounting for whatever exceptional scenarios exist for the Vault (that aren&#39;t covered by the Vault&#39;s own design.) In the situation where a large withdrawal happens, it can empty the vault balance and the strategies in the withdrawal queue. Strategies not in the withdrawal queue will have to be harvested to rebalance the funds and make the funds available again to withdraw.*
@@ -799,7 +799,7 @@ function pricePerShare()
 ```
 
 
-@notice Gives the price for a single Vault share.    
+Gives the price for a single Vault share.    
 
 
 *See dev note on `withdraw`.*
@@ -822,7 +822,7 @@ function addStrategy(address,uint256,uint256,uint256,uint256)
 ```
 
 
-@notice Add a Strategy to the Vault. This may only be called by governance.    
+Add a Strategy to the Vault. This may only be called by governance.    
 
 
 *The Strategy will be appended to `withdrawalQueue`, call `setWithdrawalQueue` to change the order.*
@@ -849,7 +849,7 @@ function updateStrategyDebtRatio(address,uint256)
 ```
 
 
-@notice Change the quantity of assets `strategy` may manage. This may be called by governance or management.    
+Change the quantity of assets `strategy` may manage. This may be called by governance or management.    
 
 
 
@@ -871,7 +871,7 @@ function updateStrategyMinDebtPerHarvest(address,uint256)
 ```
 
 
-@notice Change the quantity assets per block this Vault may deposit to or withdraw from `strategy`. This may only be called by governance or management.    
+Change the quantity assets per block this Vault may deposit to or withdraw from `strategy`. This may only be called by governance or management.    
 
 
 
@@ -893,7 +893,7 @@ function updateStrategyMaxDebtPerHarvest(address,uint256)
 ```
 
 
-@notice Change the quantity assets per block this Vault may deposit to or withdraw from `strategy`. This may only be called by governance or management.    
+Change the quantity assets per block this Vault may deposit to or withdraw from `strategy`. This may only be called by governance or management.    
 
 
 
@@ -915,7 +915,7 @@ function updateStrategyPerformanceFee(address,uint256)
 ```
 
 
-@notice Change the fee the strategist will receive based on this Vault&#39;s performance. This may only be called by governance.    
+Change the fee the strategist will receive based on this Vault&#39;s performance. This may only be called by governance.    
 
 
 
@@ -937,7 +937,7 @@ function migrateStrategy(address,address)
 ```
 
 
-@notice Migrates a Strategy, including all assets from `oldVersion` to `newVersion`. This may only be called by governance.    
+Migrates a Strategy, including all assets from `oldVersion` to `newVersion`. This may only be called by governance.    
 
 
 *Strategy must successfully migrate all capital and positions to new Strategy, or else this will upset the balance of the Vault. The new Strategy should be &#34;empty&#34; e.g. have no prior commitments to this Vault, otherwise it could have issues.*
@@ -961,7 +961,7 @@ function revokeStrategy()
 ```
 
 
-@notice Revoke a Strategy, setting its debt limit to 0 and preventing any future deposits. This function should only be used in the scenario where the Strategy is being retired but no migration of the positions are possible, or in the extreme scenario that the Strategy needs to be put into &#34;Emergency Exit&#34; mode in order for it to exit as quickly as possible. The latter scenario could be for any reason that is considered &#34;critical&#34; that the Strategy exits its position as fast as possible, such as a sudden change in market conditions leading to losses, or an imminent failure in an external dependency. This may only be called by governance, the guardian, or the Strategy itself. Note that a Strategy will only revoke itself during emergency shutdown.    
+Revoke a Strategy, setting its debt limit to 0 and preventing any future deposits. This function should only be used in the scenario where the Strategy is being retired but no migration of the positions are possible, or in the extreme scenario that the Strategy needs to be put into &#34;Emergency Exit&#34; mode in order for it to exit as quickly as possible. The latter scenario could be for any reason that is considered &#34;critical&#34; that the Strategy exits its position as fast as possible, such as a sudden change in market conditions leading to losses, or an imminent failure in an external dependency. This may only be called by governance, the guardian, or the Strategy itself. Note that a Strategy will only revoke itself during emergency shutdown.    
 
 
 
@@ -1001,7 +1001,7 @@ function addStrategyToQueue(address)
 ```
 
 
-@notice Adds `strategy` to `withdrawalQueue`. This may only be called by governance or management.    
+Adds `strategy` to `withdrawalQueue`. This may only be called by governance or management.    
 
 
 *The Strategy will be appended to `withdrawalQueue`, call `setWithdrawalQueue` to change the order.*
@@ -1024,7 +1024,7 @@ function removeStrategyFromQueue(address)
 ```
 
 
-@notice Remove `strategy` from `withdrawalQueue`. This may only be called by governance or management.    
+Remove `strategy` from `withdrawalQueue`. This may only be called by governance or management.    
 
 
 *We don&#39;t do this with revokeStrategy because it should still be possible to withdraw from the Strategy if it&#39;s unwinding.*
@@ -1047,7 +1047,7 @@ function debtOutstanding()
 ```
 
 
-@notice Determines if `strategy` is past its debt limit and if any tokens should be withdrawn to the Vault.    
+Determines if `strategy` is past its debt limit and if any tokens should be withdrawn to the Vault.    
 
 
 
@@ -1099,7 +1099,7 @@ function creditAvailable()
 ```
 
 
-@notice Amount of tokens in Vault a Strategy has access to as a credit line. This will check the Strategy&#39;s debt limit, as well as the tokens available in the Vault, and determine the maximum amount of tokens (if any) the Strategy may draw on. In the rare case the Vault is in emergency shutdown this will return 0.    
+Amount of tokens in Vault a Strategy has access to as a credit line. This will check the Strategy&#39;s debt limit, as well as the tokens available in the Vault, and determine the maximum amount of tokens (if any) the Strategy may draw on. In the rare case the Vault is in emergency shutdown this will return 0.    
 
 
 
@@ -1151,7 +1151,7 @@ function expectedReturn()
 ```
 
 
-@notice Provide an accurate expected value for the return this `strategy` would provide to the Vault the next time `report()` is called (since the last time it was called).    
+Provide an accurate expected value for the return this `strategy` would provide to the Vault the next time `report()` is called (since the last time it was called).    
 
 
 
@@ -1203,7 +1203,7 @@ function report(uint256,uint256,uint256)
 ```
 
 
-@notice Reports the amount of assets the calling Strategy has free (usually in terms of ROI). The performance fee is determined here, off of the strategy&#39;s profits (if any), and sent to governance. The strategist&#39;s fee is also determined here (off of profits), to be handled according to the strategist on the next harvest. This may only be called by a Strategy managed by this Vault.    
+Reports the amount of assets the calling Strategy has free (usually in terms of ROI). The performance fee is determined here, off of the strategy&#39;s profits (if any), and sent to governance. The strategist&#39;s fee is also determined here (off of profits), to be handled according to the strategist on the next harvest. This may only be called by a Strategy managed by this Vault.    
 
 
 *For approved strategies, this is the most efficient behavior. The Strategy reports back what it has free, then Vault &#34;decides&#34; whether to take some back or give it more. Note that the most it can take is `gain + _debtPayment`, and the most it can give is all of the remaining reserves. Anything outside of those bounds is abnormal behavior. All approved strategies must have increased diligence around calling this function, as abnormal behavior could become catastrophic.*
@@ -1234,7 +1234,7 @@ function sweep(address)
 ```
 
 
-@notice Removes tokens from this Vault that are not the type of token managed by this Vault. This may be used in case of accidentally sending the wrong kind of token to this Vault. Tokens will be sent to `governance`. This will fail if an attempt is made to sweep the tokens that this Vault manages. This may only be called by governance.    
+Removes tokens from this Vault that are not the type of token managed by this Vault. This may be used in case of accidentally sending the wrong kind of token to this Vault. Tokens will be sent to `governance`. This will fail if an attempt is made to sweep the tokens that this Vault manages. This may only be called by governance.    
 
 
 

--- a/templates/contract.ejs
+++ b/templates/contract.ejs
@@ -22,7 +22,7 @@ function <%= methodName %>
 ```
 
 <% if (method.notice) { %>
-@notice <%= method.notice %>    
+<%= method.notice %>    
 <% } %>
 <% if (method.details) { %>
 *<%= method.details %>*

--- a/versioned_docs/version-0.3.0/smart-contracts/BaseStrategy.md
+++ b/versioned_docs/version-0.3.0/smart-contracts/BaseStrategy.md
@@ -8,7 +8,7 @@
   function apiVersion(
   ) public returns (string)
 ```
-@notice
+
  Used to track which version of `StrategyAPI` this Strategy
  implements.
 
@@ -41,7 +41,7 @@ This Strategy's name.
   function delegatedAssets(
   ) external returns (uint256)
 ```
-@notice
+
  The amount (priced in want) of the total assets managed by this strategy should not count
  towards Yearn's TVL calculations.
 @dev
@@ -61,7 +61,7 @@ This Strategy's name.
     address _vault
   ) public
 ```
-@notice
+
  Initializes the Strategy, this is called only once, when the
  contract is deployed.
 
@@ -78,7 +78,7 @@ This Strategy's name.
     address _strategist
   ) external
 ```
-@notice
+
  Used to change `strategist`.
 
  This may only be called by governance or the existing strategist.
@@ -95,7 +95,7 @@ This Strategy's name.
     address _keeper
   ) external
 ```
-@notice
+
  Used to change `keeper`.
 
  `keeper` is the only address that may call `tend()` or `harvest()`,
@@ -118,7 +118,7 @@ This Strategy's name.
     address _rewards
   ) external
 ```
-@notice
+
  Used to change `rewards`. Any distributed rewards will cease flowing
  to the old address and begin flowing to this address once the change
  is in effect.
@@ -137,7 +137,7 @@ This Strategy's name.
     uint256 _delay
   ) external
 ```
-@notice
+
  Used to change `maxReportDelay`. `maxReportDelay` is the maximum number
  of blocks that should pass for `harvest()` to be called.
 
@@ -159,7 +159,7 @@ This Strategy's name.
     uint256 _profitFactor
   ) external
 ```
-@notice
+
  Used to change `profitFactor`. `profitFactor` is used to determine
  if it's worthwhile to harvest, given gas costs. (See `harvestTrigger()`
  for more details.)
@@ -179,7 +179,7 @@ This Strategy's name.
     uint256 _debtThreshold
   ) external
 ```
-@notice
+
  Sets how far the Strategy can go into loss without a harvest and report
  being required.
 
@@ -211,7 +211,7 @@ on protected functions in the Strategy.
   function estimatedTotalAssets(
   ) public returns (uint256)
 ```
-@notice
+
  Provide an accurate estimate for the total amount of assets
  (principle + return) that this Strategy is currently managing,
  denominated in terms of `want` tokens.
@@ -329,7 +329,7 @@ NOTE: The invariant `_amountFreed + _loss <= _amountNeeded` should always be mai
     uint256 callCost
   ) public returns (bool)
 ```
-@notice
+
  Provide a signal to the keeper that `tend()` should be called. The
  keeper will provide the estimated gas cost that they would pay to call
  `tend()`, and this function should use that estimate to make a
@@ -359,7 +359,7 @@ NOTE: The invariant `_amountFreed + _loss <= _amountNeeded` should always be mai
   function tend(
   ) external
 ```
-@notice
+
  Adjust the Strategy's position. The purpose of tending isn't to
  realize gains, but to maximize yield by reinvesting any returns.
 
@@ -375,7 +375,7 @@ NOTE: The invariant `_amountFreed + _loss <= _amountNeeded` should always be mai
     uint256 callCost
   ) public returns (bool)
 ```
-@notice
+
  Provide a signal to the keeper that `harvest()` should be called. The
  keeper will provide the estimated gas cost that they would pay to call
  `harvest()`, and this function should use that estimate to make a
@@ -417,7 +417,7 @@ NOTE: The invariant `_amountFreed + _loss <= _amountNeeded` should always be mai
   function harvest(
   ) external
 ```
-@notice
+
  Harvests the Strategy, recognizing any profits or losses and adjusting
  the Strategy's position.
 
@@ -441,7 +441,7 @@ NOTE: The invariant `_amountFreed + _loss <= _amountNeeded` should always be mai
     uint256 _amountNeeded
   ) external returns (uint256 _loss)
 ```
-@notice
+
  Withdraws `_amountNeeded` to `vault`.
 
  This may only be called by the Vault.
@@ -473,7 +473,7 @@ value.
     address _newStrategy
   ) external
 ```
-@notice
+
  Transfers all `want` from this Strategy to `_newStrategy`.
 
  This may only be called by governance or the Vault.
@@ -491,7 +491,7 @@ value.
   function setEmergencyExit(
   ) external
 ```
-@notice
+
  Activates emergency exit. Once activated, the Strategy will exit its
  position upon the next harvest, depositing all funds into the Vault as
  quickly as is reasonable given on-chain conditions.
@@ -531,7 +531,7 @@ Example:
     address _token
   ) external
 ```
-@notice
+
  Removes tokens from this Strategy that are not the type of tokens
  managed by this Strategy. This may be used in case of accidentally
  sending the wrong kind of token to this Strategy.

--- a/versioned_docs/version-0.3.1/smart-contracts/BaseStrategy.md
+++ b/versioned_docs/version-0.3.1/smart-contracts/BaseStrategy.md
@@ -8,7 +8,7 @@
   function apiVersion(
   ) public returns (string)
 ```
-@notice
+
  Used to track which version of `StrategyAPI` this Strategy
  implements.
 
@@ -41,7 +41,7 @@ This Strategy's name.
   function delegatedAssets(
   ) external returns (uint256)
 ```
-@notice
+
  The amount (priced in want) of the total assets managed by this strategy should not count
  towards Yearn's TVL calculations.
 @dev
@@ -61,7 +61,7 @@ This Strategy's name.
     address _vault
   ) public
 ```
-@notice
+
  Initializes the Strategy, this is called only once, when the
  contract is deployed.
 
@@ -78,7 +78,7 @@ This Strategy's name.
     address _strategist
   ) external
 ```
-@notice
+
  Used to change `strategist`.
 
  This may only be called by governance or the existing strategist.
@@ -95,7 +95,7 @@ This Strategy's name.
     address _keeper
   ) external
 ```
-@notice
+
  Used to change `keeper`.
 
  `keeper` is the only address that may call `tend()` or `harvest()`,
@@ -118,7 +118,7 @@ This Strategy's name.
     address _rewards
   ) external
 ```
-@notice
+
  Used to change `rewards`. EOA or smart contract which has the permission
  to pull rewards from the vault.
 
@@ -136,7 +136,7 @@ This Strategy's name.
     uint256 _delay
   ) external
 ```
-@notice
+
  Used to change `maxReportDelay`. `maxReportDelay` is the maximum number
  of blocks that should pass for `harvest()` to be called.
 
@@ -158,7 +158,7 @@ This Strategy's name.
     uint256 _profitFactor
   ) external
 ```
-@notice
+
  Used to change `profitFactor`. `profitFactor` is used to determine
  if it's worthwhile to harvest, given gas costs. (See `harvestTrigger()`
  for more details.)
@@ -178,7 +178,7 @@ This Strategy's name.
     uint256 _debtThreshold
   ) external
 ```
-@notice
+
  Sets how far the Strategy can go into loss without a harvest and report
  being required.
 
@@ -201,7 +201,7 @@ being required to report to the Vault.
     string _metadataURI
   ) external
 ```
-@notice
+
  Used to change `metadataURI`. `metadataURI` is used to store the URI
 of the file describing the strategy.
 
@@ -228,7 +228,7 @@ on protected functions in the Strategy.
   function estimatedTotalAssets(
   ) public returns (uint256)
 ```
-@notice
+
  Provide an accurate estimate for the total amount of assets
  (principle + return) that this Strategy is currently managing,
  denominated in terms of `want` tokens.
@@ -334,7 +334,7 @@ NOTE: The invariant `_liquidatedAmount + _loss <= _amountNeeded` should always b
     uint256 callCost
   ) public returns (bool)
 ```
-@notice
+
  Provide a signal to the keeper that `tend()` should be called. The
  keeper will provide the estimated gas cost that they would pay to call
  `tend()`, and this function should use that estimate to make a
@@ -364,7 +364,7 @@ NOTE: The invariant `_liquidatedAmount + _loss <= _amountNeeded` should always b
   function tend(
   ) external
 ```
-@notice
+
  Adjust the Strategy's position. The purpose of tending isn't to
  realize gains, but to maximize yield by reinvesting any returns.
 
@@ -380,7 +380,7 @@ NOTE: The invariant `_liquidatedAmount + _loss <= _amountNeeded` should always b
     uint256 callCost
   ) public returns (bool)
 ```
-@notice
+
  Provide a signal to the keeper that `harvest()` should be called. The
  keeper will provide the estimated gas cost that they would pay to call
  `harvest()`, and this function should use that estimate to make a
@@ -422,7 +422,7 @@ NOTE: The invariant `_liquidatedAmount + _loss <= _amountNeeded` should always b
   function harvest(
   ) external
 ```
-@notice
+
  Harvests the Strategy, recognizing any profits or losses and adjusting
  the Strategy's position.
 
@@ -446,7 +446,7 @@ NOTE: The invariant `_liquidatedAmount + _loss <= _amountNeeded` should always b
     uint256 _amountNeeded
   ) external returns (uint256 _loss)
 ```
-@notice
+
  Withdraws `_amountNeeded` to `vault`.
 
  This may only be called by the Vault.
@@ -478,7 +478,7 @@ value.
     address _newStrategy
   ) external
 ```
-@notice
+
  Transfers all `want` from this Strategy to `_newStrategy`.
 
  This may only be called by governance or the Vault.
@@ -496,7 +496,7 @@ value.
   function setEmergencyExit(
   ) external
 ```
-@notice
+
  Activates emergency exit. Once activated, the Strategy will exit its
  position upon the next harvest, depositing all funds into the Vault as
  quickly as is reasonable given on-chain conditions.
@@ -536,7 +536,7 @@ Example:
     address _token
   ) external
 ```
-@notice
+
  Removes tokens from this Strategy that are not the type of tokens
  managed by this Strategy. This may be used in case of accidentally
  sending the wrong kind of token to this Strategy.

--- a/versioned_docs/version-0.3.1/smart-contracts/registry.md
+++ b/versioned_docs/version-0.3.1/smart-contracts/registry.md
@@ -16,7 +16,7 @@ function setGovernance(address)
 ```
 
 
-@notice Starts the 1st phase of the governance transfer.    
+Starts the 1st phase of the governance transfer.    
 
 
 *Throws if the caller is not current governance.*
@@ -39,7 +39,7 @@ function acceptGovernance()
 ```
 
 
-@notice Completes the 2nd phase of the governance transfer.    
+Completes the 2nd phase of the governance transfer.    
 
 
 *Throws if the caller is not the pending caller. Emits a `NewGovernance` event.*
@@ -56,7 +56,7 @@ function latestRelease()
 ```
 
 
-@notice Returns the api version of the latest release.    
+Returns the api version of the latest release.    
 
 
 *Throws if no releases are registered yet.*
@@ -79,7 +79,7 @@ function latestVault(address)
 ```
 
 
-@notice Returns the latest deployed vault for the given token.    
+Returns the latest deployed vault for the given token.    
 
 
 *Throws if no deployments are endorsed yet for the given token.*
@@ -108,7 +108,7 @@ function newRelease(address)
 ```
 
 
-@notice Add a previously deployed Vault as the template contract for the latest release, to be used by further &#34;forwarder-style&#34; delegatecall proxy contracts that can be deployed from the registry throw other methods (to save gas).    
+Add a previously deployed Vault as the template contract for the latest release, to be used by further &#34;forwarder-style&#34; delegatecall proxy contracts that can be deployed from the registry throw other methods (to save gas).    
 
 
 *Throws if caller isn&#39;t `self.governance`. Throws if `vault`&#39;s governance isn&#39;t `self.governance`. Throws if the api version is the same as the previous release. Emits a `NewVault` event.*
@@ -131,7 +131,7 @@ function newVault(address,address,address,string,string)
 ```
 
 
-@notice Create a new vault for the given token using the latest release in the registry, as a simple &#34;forwarder-style&#34; delegatecall proxy to the latest release. Also adds the new vault to the list of &#34;endorsed&#34; vaults for that token.    
+Create a new vault for the given token using the latest release in the registry, as a simple &#34;forwarder-style&#34; delegatecall proxy to the latest release. Also adds the new vault to the list of &#34;endorsed&#34; vaults for that token.    
 
 
 *`governance` is set in the new vault as `self.governance`, with no ability to override. Throws if caller isn&#39;t `self.governance`. Throws if no releases are registered yet. Throws if there already is a deployment for the given token with the latest api version. Emits a `NewVault` event.*
@@ -164,7 +164,7 @@ function newExperimentalVault(address,address,address,address,string,string)
 ```
 
 
-@notice Create a new vault for the given token using the latest release in the registry, as a simple &#34;forwarder-style&#34; delegatecall proxy to the latest release. Does not add the new vault to the list of &#34;endorsed&#34; vaults for that token.    
+Create a new vault for the given token using the latest release in the registry, as a simple &#34;forwarder-style&#34; delegatecall proxy to the latest release. Does not add the new vault to the list of &#34;endorsed&#34; vaults for that token.    
 
 
 *Throws if no releases are registered yet. Emits a `NewExperimentalVault` event.*
@@ -198,7 +198,7 @@ function endorseVault(address)
 ```
 
 
-@notice Adds an existing vault to the list of &#34;endorsed&#34; vaults for that token.    
+Adds an existing vault to the list of &#34;endorsed&#34; vaults for that token.    
 
 
 *`governance` is set in the new vault as `self.governance`, with no ability to override. Throws if caller isn&#39;t `self.governance`. Throws if `vault`&#39;s governance isn&#39;t `self.governance`. Throws if no releases are registered yet. Throws if `vault`&#39;s api version does not match latest release. Throws if there already is a deployment for the vault&#39;s token with the latest api version. Emits a `NewVault` event.*
@@ -221,7 +221,7 @@ function setBanksy(address)
 ```
 
 
-@notice Set the ability of a particular tagger to tag current vaults.    
+Set the ability of a particular tagger to tag current vaults.    
 
 
 *Throws if caller is not `self.governance`.*
@@ -267,7 +267,7 @@ function tagVault(address,string)
 ```
 
 
-@notice Tag a Vault with a message.    
+Tag a Vault with a message.    
 
 
 *Throws if caller is not `self.governance` or an approved tagger. Emits a `VaultTagged` event.*

--- a/versioned_docs/version-0.3.1/smart-contracts/vault.md
+++ b/versioned_docs/version-0.3.1/smart-contracts/vault.md
@@ -20,7 +20,7 @@ function initialize(address,address,address,string,string)
 ```
 
 
-@notice Initializes the Vault, this is called only once, when the contract is deployed. The performance fee is set to 10% of yield, per Strategy. The management fee is set to 2%, per year. The initial deposit limit is set to 0 (deposits disabled); it must be updated after initialization.    
+Initializes the Vault, this is called only once, when the contract is deployed. The performance fee is set to 10% of yield, per Strategy. The management fee is set to 2%, per year. The initial deposit limit is set to 0 (deposits disabled); it must be updated after initialization.    
 
 
 *If `nameOverride` is not specified, the name will be &#39;yearn&#39; combined with the name of `token`. If `symbolOverride` is not specified, the symbol will be &#39;y&#39; combined with the symbol of `token`.*
@@ -74,7 +74,7 @@ function apiVersion()
 ```
 
 
-@notice Used to track the deployed version of this contract. In practice you can use this version number to compare with Yearn&#39;s GitHub and determine which version of the source matches this deployed contract.    
+Used to track the deployed version of this contract. In practice you can use this version number to compare with Yearn&#39;s GitHub and determine which version of the source matches this deployed contract.    
 
 
 *All strategies must have an `apiVersion()` that matches the Vault&#39;s `API_VERSION`.*
@@ -97,7 +97,7 @@ function setName(string)
 ```
 
 
-@notice Used to change the value of `name`. This may only be called by governance.    
+Used to change the value of `name`. This may only be called by governance.    
 
 
 
@@ -118,7 +118,7 @@ function setSymbol(string)
 ```
 
 
-@notice Used to change the value of `symbol`. This may only be called by governance.    
+Used to change the value of `symbol`. This may only be called by governance.    
 
 
 
@@ -139,7 +139,7 @@ function setGovernance(address)
 ```
 
 
-@notice Nominate a new address to use as governance. The change does not go into effect immediately. This function sets a pending change, and the governance address is not updated until the proposed governance address has accepted the responsibility. This may only be called by the current governance address.    
+Nominate a new address to use as governance. The change does not go into effect immediately. This function sets a pending change, and the governance address is not updated until the proposed governance address has accepted the responsibility. This may only be called by the current governance address.    
 
 
 
@@ -160,7 +160,7 @@ function acceptGovernance()
 ```
 
 
-@notice Once a new governance address has been proposed using setGovernance(), this function may be called by the proposed address to accept the responsibility of taking over governance for this contract. This may only be called by the proposed governance address.    
+Once a new governance address has been proposed using setGovernance(), this function may be called by the proposed address to accept the responsibility of taking over governance for this contract. This may only be called by the proposed governance address.    
 
 
 *setGovernance() should be called by the existing governance address, prior to calling this function.*
@@ -177,7 +177,7 @@ function setManagement(address)
 ```
 
 
-@notice Changes the management address. Management is able to make some investment decisions adjusting parameters. This may only be called by governance.    
+Changes the management address. Management is able to make some investment decisions adjusting parameters. This may only be called by governance.    
 
 
 
@@ -198,7 +198,7 @@ function setGuestList(address)
 ```
 
 
-@notice Used to set or change `guestList`. A guest list is another contract that dictates who is allowed to participate in a Vault (and transfer shares). This may only be called by governance.    
+Used to set or change `guestList`. A guest list is another contract that dictates who is allowed to participate in a Vault (and transfer shares). This may only be called by governance.    
 
 
 
@@ -219,7 +219,7 @@ function setRewards(address)
 ```
 
 
-@notice Changes the rewards address. Any distributed rewards will cease flowing to the old address and begin flowing to this address once the change is in effect. This will not change any Strategy reports in progress, only new reports made after this change goes into effect. This may only be called by governance.    
+Changes the rewards address. Any distributed rewards will cease flowing to the old address and begin flowing to this address once the change is in effect. This will not change any Strategy reports in progress, only new reports made after this change goes into effect. This may only be called by governance.    
 
 
 
@@ -240,7 +240,7 @@ function setDepositLimit(uint256)
 ```
 
 
-@notice Changes the maximum amount of tokens that can be deposited in this Vault. Note, this is not how much may be deposited by a single depositor, but the maximum amount that may be deposited across all depositors. This may only be called by governance.    
+Changes the maximum amount of tokens that can be deposited in this Vault. Note, this is not how much may be deposited by a single depositor, but the maximum amount that may be deposited across all depositors. This may only be called by governance.    
 
 
 
@@ -261,7 +261,7 @@ function setPerformanceFee(uint256)
 ```
 
 
-@notice Used to change the value of `performanceFee`. Should set this value below the maximum strategist performance fee. This may only be called by governance.    
+Used to change the value of `performanceFee`. Should set this value below the maximum strategist performance fee. This may only be called by governance.    
 
 
 
@@ -282,7 +282,7 @@ function setManagementFee(uint256)
 ```
 
 
-@notice Used to change the value of `managementFee`. This may only be called by governance.    
+Used to change the value of `managementFee`. This may only be called by governance.    
 
 
 
@@ -303,7 +303,7 @@ function setGuardian(address)
 ```
 
 
-@notice Used to change the address of `guardian`. This may only be called by governance or the existing guardian.    
+Used to change the address of `guardian`. This may only be called by governance or the existing guardian.    
 
 
 
@@ -324,7 +324,7 @@ function setEmergencyShutdown(bool)
 ```
 
 
-@notice Activates or deactivates Vault mode where all Strategies go into full withdrawal. During Emergency Shutdown: 1. No Users may deposit into the Vault (but may withdraw as usual.) 2. Governance may not add new Strategies. 3. Each Strategy must pay back their debt as quickly as reasonable to minimally affect their position. 4. Only Governance may undo Emergency Shutdown. See contract level note for further details. This may only be called by governance or the guardian.    
+Activates or deactivates Vault mode where all Strategies go into full withdrawal. During Emergency Shutdown: 1. No Users may deposit into the Vault (but may withdraw as usual.) 2. Governance may not add new Strategies. 3. Each Strategy must pay back their debt as quickly as reasonable to minimally affect their position. 4. Only Governance may undo Emergency Shutdown. See contract level note for further details. This may only be called by governance or the guardian.    
 
 
 
@@ -345,7 +345,7 @@ function setWithdrawalQueue(address[20])
 ```
 
 
-@notice Updates the withdrawalQueue to match the addresses and order specified by `queue`. There can be fewer strategies than the maximum, as well as fewer than the total number of strategies active in the vault. `withdrawalQueue` will be updated in a gas-efficient manner, assuming the input is well- ordered with 0x0 only at the end. This may only be called by governance or management.    
+Updates the withdrawalQueue to match the addresses and order specified by `queue`. There can be fewer strategies than the maximum, as well as fewer than the total number of strategies active in the vault. `withdrawalQueue` will be updated in a gas-efficient manner, assuming the input is well- ordered with 0x0 only at the end. This may only be called by governance or management.    
 
 
 *This is order sensitive, specify the addresses in the order in which funds should be withdrawn (so `queue`[0] is the first Strategy withdrawn from, `queue`[1] is the second, etc.) This means that the least impactful Strategy (the Strategy that will have its core positions impacted the least by having funds removed) should be at `queue`[0], then the next least impactful at `queue`[1], and so on.*
@@ -368,7 +368,7 @@ function transfer(address,uint256)
 ```
 
 
-@notice Transfers shares from the caller&#39;s address to `receiver`. This function will always return true, unless the user is attempting to transfer shares to this contract&#39;s address, or to 0x0.    
+Transfers shares from the caller&#39;s address to `receiver`. This function will always return true, unless the user is attempting to transfer shares to this contract&#39;s address, or to 0x0.    
 
 
 
@@ -396,7 +396,7 @@ function transferFrom(address,address,uint256)
 ```
 
 
-@notice Transfers `amount` shares from `sender` to `receiver`. This operation will always return true, unless the user is attempting to transfer shares to this contract&#39;s address, or to 0x0. Unless the caller has given this contract unlimited approval, transfering shares will decrement the caller&#39;s `allowance` by `amount`.    
+Transfers `amount` shares from `sender` to `receiver`. This operation will always return true, unless the user is attempting to transfer shares to this contract&#39;s address, or to 0x0. Unless the caller has given this contract unlimited approval, transfering shares will decrement the caller&#39;s `allowance` by `amount`.    
 
 
 
@@ -491,7 +491,7 @@ function permit(address,address,uint256,uint256,bytes)
 ```
 
 
-@notice Approves spender by owner&#39;s signature to expend owner&#39;s tokens. See https://eips.ethereum.org/EIPS/eip-2612.    
+Approves spender by owner&#39;s signature to expend owner&#39;s tokens. See https://eips.ethereum.org/EIPS/eip-2612.    
 
 
 
@@ -522,7 +522,7 @@ function totalAssets()
 ```
 
 
-@notice Returns the total quantity of all assets under control of this Vault, whether they&#39;re loaned out to a Strategy, or currently held in the Vault.    
+Returns the total quantity of all assets under control of this Vault, whether they&#39;re loaned out to a Strategy, or currently held in the Vault.    
 
 
 
@@ -543,7 +543,7 @@ function deposit()
 ```
 
 
-@notice Deposits `_amount` `token`, issuing shares to `recipient`. If the Vault is in Emergency Shutdown, deposits will not be accepted and this call will fail.    
+Deposits `_amount` `token`, issuing shares to `recipient`. If the Vault is in Emergency Shutdown, deposits will not be accepted and this call will fail.    
 
 
 *Measuring quantity of shares to issues is based on the total outstanding debt that this contract has (&#34;expected value&#34;) instead of the total balance sheet it has (&#34;estimated value&#34;) has important security considerations, and is done intentionally. If this value were measured against external systems, it could be purposely manipulated by an attacker to withdraw more assets than they otherwise should be able to claim by redeeming their shares. On deposit, this means that shares are issued against the total amount that the deposited capital can be given in service of the debt that Strategies assume. If that number were to be lower than the &#34;expected value&#34; at some future point, depositing shares via this method could entitle the depositor to *less* than the deposited value once the &#34;realized value&#34; is updated from further reports by the Strategies to the Vaults. Care should be taken by integrators to account for this discrepancy, by using the view-only methods of this contract (both off-chain and on-chain) to determine if depositing into the Vault is a &#34;good idea&#34;.*
@@ -629,7 +629,7 @@ function maxAvailableShares()
 ```
 
 
-@notice Determines the maximum quantity of shares this Vault can facilitate a withdrawal for, factoring in assets currently residing in the Vault, as well as those deployed to strategies on the Vault&#39;s balance sheet.    
+Determines the maximum quantity of shares this Vault can facilitate a withdrawal for, factoring in assets currently residing in the Vault, as well as those deployed to strategies on the Vault&#39;s balance sheet.    
 
 
 *Regarding how shares are calculated, see dev note on `deposit`. If you want to calculated the maximum a user could withdraw up to, you want to use this function. Note that the amount provided by this function is the theoretical maximum possible from withdrawing, the real amount depends on the realized losses incurred during withdrawal.*
@@ -652,7 +652,7 @@ function withdraw()
 ```
 
 
-@notice Withdraws the calling account&#39;s tokens from this Vault, redeeming amount `_shares` for an appropriate amount of tokens. See note on `setWithdrawalQueue` for further details of withdrawal ordering and behavior.    
+Withdraws the calling account&#39;s tokens from this Vault, redeeming amount `_shares` for an appropriate amount of tokens. See note on `setWithdrawalQueue` for further details of withdrawal ordering and behavior.    
 
 
 *Measuring the value of shares is based on the total outstanding debt that this contract has (&#34;expected value&#34;) instead of the total balance sheet it has (&#34;estimated value&#34;) has important security considerations, and is done intentionally. If this value were measured against external systems, it could be purposely manipulated by an attacker to withdraw more assets than they otherwise should be able to claim by redeeming their shares. On withdrawal, this means that shares are redeemed against the total amount that the deposited capital had &#34;realized&#34; since the point it was deposited, up until the point it was withdrawn. If that number were to be higher than the &#34;expected value&#34; at some future point, withdrawing shares via this method could entitle the depositor to *more* than the expected value once the &#34;realized value&#34; is updated from further reports by the Strategies to the Vaults. Under exceptional scenarios, this could cause earlier withdrawals to earn &#34;more&#34; of the underlying assets than Users might otherwise be entitled to, if the Vault&#39;s estimated value were otherwise measured through external means, accounting for whatever exceptional scenarios exist for the Vault (that aren&#39;t covered by the Vault&#39;s own design.)*
@@ -770,7 +770,7 @@ function pricePerShare()
 ```
 
 
-@notice Gives the price for a single Vault share.    
+Gives the price for a single Vault share.    
 
 
 *See dev note on `withdraw`.*
@@ -793,7 +793,7 @@ function addStrategy(address,uint256,uint256,uint256)
 ```
 
 
-@notice Add a Strategy to the Vault. This may only be called by governance.    
+Add a Strategy to the Vault. This may only be called by governance.    
 
 
 *The Strategy will be appended to `withdrawalQueue`, call `setWithdrawalQueue` to change the order.*
@@ -819,7 +819,7 @@ function updateStrategyDebtRatio(address,uint256)
 ```
 
 
-@notice Change the quantity of assets `strategy` may manage. This may be called by governance or management.    
+Change the quantity of assets `strategy` may manage. This may be called by governance or management.    
 
 
 
@@ -841,7 +841,7 @@ function updateStrategyRateLimit(address,uint256)
 ```
 
 
-@notice Change the quantity assets per block this Vault may deposit to or withdraw from `strategy`. This may only be called by governance or management.    
+Change the quantity assets per block this Vault may deposit to or withdraw from `strategy`. This may only be called by governance or management.    
 
 
 
@@ -863,7 +863,7 @@ function updateStrategyPerformanceFee(address,uint256)
 ```
 
 
-@notice Change the fee the strategist will receive based on this Vault&#39;s performance. This may only be called by governance.    
+Change the fee the strategist will receive based on this Vault&#39;s performance. This may only be called by governance.    
 
 
 
@@ -885,7 +885,7 @@ function migrateStrategy(address,address)
 ```
 
 
-@notice Migrates a Strategy, including all assets from `oldVersion` to `newVersion`. This may only be called by governance.    
+Migrates a Strategy, including all assets from `oldVersion` to `newVersion`. This may only be called by governance.    
 
 
 *Strategy must successfully migrate all capital and positions to new Strategy, or else this will upset the balance of the Vault. The new Strategy should be &#34;empty&#34; e.g. have no prior commitments to this Vault, otherwise it could have issues.*
@@ -909,7 +909,7 @@ function revokeStrategy()
 ```
 
 
-@notice Revoke a Strategy, setting its debt limit to 0 and preventing any future deposits. This function should only be used in the scenario where the Strategy is being retired but no migration of the positions are possible, or in the extreme scenario that the Strategy needs to be put into &#34;Emergency Exit&#34; mode in order for it to exit as quickly as possible. The latter scenario could be for any reason that is considered &#34;critical&#34; that the Strategy exits its position as fast as possible, such as a sudden change in market conditions leading to losses, or an imminent failure in an external dependency. This may only be called by governance, the guardian, or the Strategy itself. Note that a Strategy will only revoke itself during emergency shutdown.    
+Revoke a Strategy, setting its debt limit to 0 and preventing any future deposits. This function should only be used in the scenario where the Strategy is being retired but no migration of the positions are possible, or in the extreme scenario that the Strategy needs to be put into &#34;Emergency Exit&#34; mode in order for it to exit as quickly as possible. The latter scenario could be for any reason that is considered &#34;critical&#34; that the Strategy exits its position as fast as possible, such as a sudden change in market conditions leading to losses, or an imminent failure in an external dependency. This may only be called by governance, the guardian, or the Strategy itself. Note that a Strategy will only revoke itself during emergency shutdown.    
 
 
 
@@ -949,7 +949,7 @@ function addStrategyToQueue(address)
 ```
 
 
-@notice Adds `strategy` to `withdrawalQueue`. This may only be called by governance or management.    
+Adds `strategy` to `withdrawalQueue`. This may only be called by governance or management.    
 
 
 *The Strategy will be appended to `withdrawalQueue`, call `setWithdrawalQueue` to change the order.*
@@ -972,7 +972,7 @@ function removeStrategyFromQueue(address)
 ```
 
 
-@notice Remove `strategy` from `withdrawalQueue`. This may only be called by governance or management.    
+Remove `strategy` from `withdrawalQueue`. This may only be called by governance or management.    
 
 
 *We don&#39;t do this with revokeStrategy because it should still be possible to withdraw from the Strategy if it&#39;s unwinding.*
@@ -995,7 +995,7 @@ function debtOutstanding()
 ```
 
 
-@notice Determines if `strategy` is past its debt limit and if any tokens should be withdrawn to the Vault.    
+Determines if `strategy` is past its debt limit and if any tokens should be withdrawn to the Vault.    
 
 
 
@@ -1047,7 +1047,7 @@ function creditAvailable()
 ```
 
 
-@notice Amount of tokens in Vault a Strategy has access to as a credit line. This will check the Strategy&#39;s debt limit, as well as the tokens available in the Vault, and determine the maximum amount of tokens (if any) the Strategy may draw on. In the rare case the Vault is in emergency shutdown this will return 0.    
+Amount of tokens in Vault a Strategy has access to as a credit line. This will check the Strategy&#39;s debt limit, as well as the tokens available in the Vault, and determine the maximum amount of tokens (if any) the Strategy may draw on. In the rare case the Vault is in emergency shutdown this will return 0.    
 
 
 
@@ -1099,7 +1099,7 @@ function expectedReturn()
 ```
 
 
-@notice Provide an accurate expected value for the return this `strategy` would provide to the Vault the next time `report()` is called (since the last time it was called).    
+Provide an accurate expected value for the return this `strategy` would provide to the Vault the next time `report()` is called (since the last time it was called).    
 
 
 
@@ -1151,7 +1151,7 @@ function report(uint256,uint256,uint256)
 ```
 
 
-@notice Reports the amount of assets the calling Strategy has free (usually in terms of ROI). The performance fee is determined here, off of the strategy&#39;s profits (if any), and sent to governance. The strategist&#39;s fee is also determined here (off of profits), to be handled according to the strategist on the next harvest. This may only be called by a Strategy managed by this Vault.    
+Reports the amount of assets the calling Strategy has free (usually in terms of ROI). The performance fee is determined here, off of the strategy&#39;s profits (if any), and sent to governance. The strategist&#39;s fee is also determined here (off of profits), to be handled according to the strategist on the next harvest. This may only be called by a Strategy managed by this Vault.    
 
 
 *For approved strategies, this is the most efficient behavior. The Strategy reports back what it has free, then Vault &#34;decides&#34; whether to take some back or give it more. Note that the most it can take is `gain + _debtPayment`, and the most it can give is all of the remaining reserves. Anything outside of those bounds is abnormal behavior. All approved strategies must have increased diligence around calling this function, as abnormal behavior could become catastrophic.*
@@ -1182,7 +1182,7 @@ function sweep(address)
 ```
 
 
-@notice Removes tokens from this Vault that are not the type of token managed by this Vault. This may be used in case of accidentally sending the wrong kind of token to this Vault. Tokens will be sent to `governance`. This will fail if an attempt is made to sweep the tokens that this Vault manages. This may only be called by governance.    
+Removes tokens from this Vault that are not the type of token managed by this Vault. This may be used in case of accidentally sending the wrong kind of token to this Vault. Tokens will be sent to `governance`. This will fail if an attempt is made to sweep the tokens that this Vault manages. This may only be called by governance.    
 
 
 

--- a/versioned_docs/version-0.3.2/smart-contracts/BaseStrategy.md
+++ b/versioned_docs/version-0.3.2/smart-contracts/BaseStrategy.md
@@ -8,7 +8,7 @@
   function apiVersion(
   ) public returns (string)
 ```
-@notice
+
  Used to track which version of `StrategyAPI` this Strategy
  implements.
 
@@ -41,7 +41,7 @@ This Strategy's name.
   function delegatedAssets(
   ) external returns (uint256)
 ```
-@notice
+
  The amount (priced in want) of the total assets managed by this strategy should not count
  towards Yearn's TVL calculations.
 @dev
@@ -70,7 +70,7 @@ This Strategy's name.
     address _vault
   ) internal
 ```
-@notice
+
  Initializes the Strategy, this is called only once, when the
  contract is deployed.
 
@@ -87,7 +87,7 @@ This Strategy's name.
     address _strategist
   ) external
 ```
-@notice
+
  Used to change `strategist`.
 
  This may only be called by governance or the existing strategist.
@@ -104,7 +104,7 @@ This Strategy's name.
     address _keeper
   ) external
 ```
-@notice
+
  Used to change `keeper`.
 
  `keeper` is the only address that may call `tend()` or `harvest()`,
@@ -127,7 +127,7 @@ This Strategy's name.
     address _rewards
   ) external
 ```
-@notice
+
  Used to change `rewards`. EOA or smart contract which has the permission
  to pull rewards from the vault.
 
@@ -145,7 +145,7 @@ This Strategy's name.
     uint256 _delay
   ) external
 ```
-@notice
+
  Used to change `minReportDelay`. `minReportDelay` is the minimum number
  of blocks that should pass for `harvest()` to be called.
 
@@ -167,7 +167,7 @@ This Strategy's name.
     uint256 _delay
   ) external
 ```
-@notice
+
  Used to change `maxReportDelay`. `maxReportDelay` is the maximum number
  of blocks that should pass for `harvest()` to be called.
 
@@ -189,7 +189,7 @@ This Strategy's name.
     uint256 _profitFactor
   ) external
 ```
-@notice
+
  Used to change `profitFactor`. `profitFactor` is used to determine
  if it's worthwhile to harvest, given gas costs. (See `harvestTrigger()`
  for more details.)
@@ -209,7 +209,7 @@ This Strategy's name.
     uint256 _debtThreshold
   ) external
 ```
-@notice
+
  Sets how far the Strategy can go into loss without a harvest and report
  being required.
 
@@ -232,7 +232,7 @@ being required to report to the Vault.
     string _metadataURI
   ) external
 ```
-@notice
+
  Used to change `metadataURI`. `metadataURI` is used to store the URI
 of the file describing the strategy.
 
@@ -259,7 +259,7 @@ on protected functions in the Strategy.
   function estimatedTotalAssets(
   ) public returns (uint256)
 ```
-@notice
+
  Provide an accurate estimate for the total amount of assets
  (principle + return) that this Strategy is currently managing,
  denominated in terms of `want` tokens.
@@ -365,7 +365,7 @@ NOTE: The invariant `_liquidatedAmount + _loss <= _amountNeeded` should always b
     uint256 callCost
   ) public returns (bool)
 ```
-@notice
+
  Provide a signal to the keeper that `tend()` should be called. The
  keeper will provide the estimated gas cost that they would pay to call
  `tend()`, and this function should use that estimate to make a
@@ -395,7 +395,7 @@ NOTE: The invariant `_liquidatedAmount + _loss <= _amountNeeded` should always b
   function tend(
   ) external
 ```
-@notice
+
  Adjust the Strategy's position. The purpose of tending isn't to
  realize gains, but to maximize yield by reinvesting any returns.
 
@@ -411,7 +411,7 @@ NOTE: The invariant `_liquidatedAmount + _loss <= _amountNeeded` should always b
     uint256 callCost
   ) public returns (bool)
 ```
-@notice
+
  Provide a signal to the keeper that `harvest()` should be called. The
  keeper will provide the estimated gas cost that they would pay to call
  `harvest()`, and this function should use that estimate to make a
@@ -453,7 +453,7 @@ NOTE: The invariant `_liquidatedAmount + _loss <= _amountNeeded` should always b
   function harvest(
   ) external
 ```
-@notice
+
  Harvests the Strategy, recognizing any profits or losses and adjusting
  the Strategy's position.
 
@@ -477,7 +477,7 @@ NOTE: The invariant `_liquidatedAmount + _loss <= _amountNeeded` should always b
     uint256 _amountNeeded
   ) external returns (uint256 _loss)
 ```
-@notice
+
  Withdraws `_amountNeeded` to `vault`.
 
  This may only be called by the Vault.
@@ -509,7 +509,7 @@ value.
     address _newStrategy
   ) external
 ```
-@notice
+
  Transfers all `want` from this Strategy to `_newStrategy`.
 
  This may only be called by governance or the Vault.
@@ -527,7 +527,7 @@ value.
   function setEmergencyExit(
   ) external
 ```
-@notice
+
  Activates emergency exit. Once activated, the Strategy will exit its
  position upon the next harvest, depositing all funds into the Vault as
  quickly as is reasonable given on-chain conditions.
@@ -567,7 +567,7 @@ Example:
     address _token
   ) external
 ```
-@notice
+
  Removes tokens from this Strategy that are not the type of tokens
  managed by this Strategy. This may be used in case of accidentally
  sending the wrong kind of token to this Strategy.

--- a/versioned_docs/version-0.3.2/smart-contracts/registry.md
+++ b/versioned_docs/version-0.3.2/smart-contracts/registry.md
@@ -16,7 +16,7 @@ function setGovernance(address)
 ```
 
 
-@notice Starts the 1st phase of the governance transfer.    
+Starts the 1st phase of the governance transfer.    
 
 
 *Throws if the caller is not current governance.*
@@ -39,7 +39,7 @@ function acceptGovernance()
 ```
 
 
-@notice Completes the 2nd phase of the governance transfer.    
+Completes the 2nd phase of the governance transfer.    
 
 
 *Throws if the caller is not the pending caller. Emits a `NewGovernance` event.*
@@ -56,7 +56,7 @@ function latestRelease()
 ```
 
 
-@notice Returns the api version of the latest release.    
+Returns the api version of the latest release.    
 
 
 *Throws if no releases are registered yet.*
@@ -79,7 +79,7 @@ function latestVault(address)
 ```
 
 
-@notice Returns the latest deployed vault for the given token.    
+Returns the latest deployed vault for the given token.    
 
 
 *Throws if no deployments are endorsed yet for the given token.*
@@ -108,7 +108,7 @@ function newRelease(address)
 ```
 
 
-@notice Add a previously deployed Vault as the template contract for the latest release, to be used by further &#34;forwarder-style&#34; delegatecall proxy contracts that can be deployed from the registry throw other methods (to save gas).    
+Add a previously deployed Vault as the template contract for the latest release, to be used by further &#34;forwarder-style&#34; delegatecall proxy contracts that can be deployed from the registry throw other methods (to save gas).    
 
 
 *Throws if caller isn&#39;t `self.governance`. Throws if `vault`&#39;s governance isn&#39;t `self.governance`. Throws if the api version is the same as the previous release. Emits a `NewVault` event.*
@@ -131,7 +131,7 @@ function newVault(address,address,address,string,string)
 ```
 
 
-@notice Create a new vault for the given token using the latest release in the registry, as a simple &#34;forwarder-style&#34; delegatecall proxy to the latest release. Also adds the new vault to the list of &#34;endorsed&#34; vaults for that token.    
+Create a new vault for the given token using the latest release in the registry, as a simple &#34;forwarder-style&#34; delegatecall proxy to the latest release. Also adds the new vault to the list of &#34;endorsed&#34; vaults for that token.    
 
 
 *`governance` is set in the new vault as `self.governance`, with no ability to override. Throws if caller isn&#39;t `self.governance`. Throws if no releases are registered yet. Throws if there already is a deployment for the given token with the latest api version. Emits a `NewVault` event.*
@@ -164,7 +164,7 @@ function newExperimentalVault(address,address,address,address,string,string)
 ```
 
 
-@notice Create a new vault for the given token using the latest release in the registry, as a simple &#34;forwarder-style&#34; delegatecall proxy to the latest release. Does not add the new vault to the list of &#34;endorsed&#34; vaults for that token.    
+Create a new vault for the given token using the latest release in the registry, as a simple &#34;forwarder-style&#34; delegatecall proxy to the latest release. Does not add the new vault to the list of &#34;endorsed&#34; vaults for that token.    
 
 
 *Throws if no releases are registered yet. Emits a `NewExperimentalVault` event.*
@@ -198,7 +198,7 @@ function endorseVault(address)
 ```
 
 
-@notice Adds an existing vault to the list of &#34;endorsed&#34; vaults for that token.    
+Adds an existing vault to the list of &#34;endorsed&#34; vaults for that token.    
 
 
 *`governance` is set in the new vault as `self.governance`, with no ability to override. Throws if caller isn&#39;t `self.governance`. Throws if `vault`&#39;s governance isn&#39;t `self.governance`. Throws if no releases are registered yet. Throws if `vault`&#39;s api version does not match latest release. Throws if there already is a deployment for the vault&#39;s token with the latest api version. Emits a `NewVault` event.*
@@ -221,7 +221,7 @@ function setBanksy(address)
 ```
 
 
-@notice Set the ability of a particular tagger to tag current vaults.    
+Set the ability of a particular tagger to tag current vaults.    
 
 
 *Throws if caller is not `self.governance`.*
@@ -267,7 +267,7 @@ function tagVault(address,string)
 ```
 
 
-@notice Tag a Vault with a message.    
+Tag a Vault with a message.    
 
 
 *Throws if caller is not `self.governance` or an approved tagger. Emits a `VaultTagged` event.*

--- a/versioned_docs/version-0.3.2/smart-contracts/vault.md
+++ b/versioned_docs/version-0.3.2/smart-contracts/vault.md
@@ -20,7 +20,7 @@ function initialize(address,address,address,string,string)
 ```
 
 
-@notice Initializes the Vault, this is called only once, when the contract is deployed. The performance fee is set to 10% of yield, per Strategy. The management fee is set to 2%, per year. The initial deposit limit is set to 0 (deposits disabled); it must be updated after initialization.    
+Initializes the Vault, this is called only once, when the contract is deployed. The performance fee is set to 10% of yield, per Strategy. The management fee is set to 2%, per year. The initial deposit limit is set to 0 (deposits disabled); it must be updated after initialization.    
 
 
 *If `nameOverride` is not specified, the name will be &#39;yearn&#39; combined with the name of `token`. If `symbolOverride` is not specified, the symbol will be &#39;y&#39; combined with the symbol of `token`.*
@@ -74,7 +74,7 @@ function apiVersion()
 ```
 
 
-@notice Used to track the deployed version of this contract. In practice you can use this version number to compare with Yearn&#39;s GitHub and determine which version of the source matches this deployed contract.    
+Used to track the deployed version of this contract. In practice you can use this version number to compare with Yearn&#39;s GitHub and determine which version of the source matches this deployed contract.    
 
 
 *All strategies must have an `apiVersion()` that matches the Vault&#39;s `API_VERSION`.*
@@ -97,7 +97,7 @@ function setName(string)
 ```
 
 
-@notice Used to change the value of `name`. This may only be called by governance.    
+Used to change the value of `name`. This may only be called by governance.    
 
 
 
@@ -118,7 +118,7 @@ function setSymbol(string)
 ```
 
 
-@notice Used to change the value of `symbol`. This may only be called by governance.    
+Used to change the value of `symbol`. This may only be called by governance.    
 
 
 
@@ -139,7 +139,7 @@ function setGovernance(address)
 ```
 
 
-@notice Nominate a new address to use as governance. The change does not go into effect immediately. This function sets a pending change, and the governance address is not updated until the proposed governance address has accepted the responsibility. This may only be called by the current governance address.    
+Nominate a new address to use as governance. The change does not go into effect immediately. This function sets a pending change, and the governance address is not updated until the proposed governance address has accepted the responsibility. This may only be called by the current governance address.    
 
 
 
@@ -160,7 +160,7 @@ function acceptGovernance()
 ```
 
 
-@notice Once a new governance address has been proposed using setGovernance(), this function may be called by the proposed address to accept the responsibility of taking over governance for this contract. This may only be called by the proposed governance address.    
+Once a new governance address has been proposed using setGovernance(), this function may be called by the proposed address to accept the responsibility of taking over governance for this contract. This may only be called by the proposed governance address.    
 
 
 *setGovernance() should be called by the existing governance address, prior to calling this function.*
@@ -177,7 +177,7 @@ function setManagement(address)
 ```
 
 
-@notice Changes the management address. Management is able to make some investment decisions adjusting parameters. This may only be called by governance.    
+Changes the management address. Management is able to make some investment decisions adjusting parameters. This may only be called by governance.    
 
 
 
@@ -198,7 +198,7 @@ function setGuestList(address)
 ```
 
 
-@notice Used to set or change `guestList`. A guest list is another contract that dictates who is allowed to participate in a Vault (and transfer shares). This may only be called by governance.    
+Used to set or change `guestList`. A guest list is another contract that dictates who is allowed to participate in a Vault (and transfer shares). This may only be called by governance.    
 
 
 
@@ -219,7 +219,7 @@ function setRewards(address)
 ```
 
 
-@notice Changes the rewards address. Any distributed rewards will cease flowing to the old address and begin flowing to this address once the change is in effect. This will not change any Strategy reports in progress, only new reports made after this change goes into effect. This may only be called by governance.    
+Changes the rewards address. Any distributed rewards will cease flowing to the old address and begin flowing to this address once the change is in effect. This will not change any Strategy reports in progress, only new reports made after this change goes into effect. This may only be called by governance.    
 
 
 
@@ -240,7 +240,7 @@ function setLockedProfitDegration(uint256)
 ```
 
 
-@notice Changes the locked profit degration.    
+Changes the locked profit degration.    
 
 
 
@@ -261,7 +261,7 @@ function setDepositLimit(uint256)
 ```
 
 
-@notice Changes the maximum amount of tokens that can be deposited in this Vault. Note, this is not how much may be deposited by a single depositor, but the maximum amount that may be deposited across all depositors. This may only be called by governance.    
+Changes the maximum amount of tokens that can be deposited in this Vault. Note, this is not how much may be deposited by a single depositor, but the maximum amount that may be deposited across all depositors. This may only be called by governance.    
 
 
 
@@ -282,7 +282,7 @@ function setPerformanceFee(uint256)
 ```
 
 
-@notice Used to change the value of `performanceFee`. Should set this value below the maximum strategist performance fee. This may only be called by governance.    
+Used to change the value of `performanceFee`. Should set this value below the maximum strategist performance fee. This may only be called by governance.    
 
 
 
@@ -303,7 +303,7 @@ function setManagementFee(uint256)
 ```
 
 
-@notice Used to change the value of `managementFee`. This may only be called by governance.    
+Used to change the value of `managementFee`. This may only be called by governance.    
 
 
 
@@ -324,7 +324,7 @@ function setGuardian(address)
 ```
 
 
-@notice Used to change the address of `guardian`. This may only be called by governance or the existing guardian.    
+Used to change the address of `guardian`. This may only be called by governance or the existing guardian.    
 
 
 
@@ -345,7 +345,7 @@ function setEmergencyShutdown(bool)
 ```
 
 
-@notice Activates or deactivates Vault mode where all Strategies go into full withdrawal. During Emergency Shutdown: 1. No Users may deposit into the Vault (but may withdraw as usual.) 2. Governance may not add new Strategies. 3. Each Strategy must pay back their debt as quickly as reasonable to minimally affect their position. 4. Only Governance may undo Emergency Shutdown. See contract level note for further details. This may only be called by governance or the guardian.    
+Activates or deactivates Vault mode where all Strategies go into full withdrawal. During Emergency Shutdown: 1. No Users may deposit into the Vault (but may withdraw as usual.) 2. Governance may not add new Strategies. 3. Each Strategy must pay back their debt as quickly as reasonable to minimally affect their position. 4. Only Governance may undo Emergency Shutdown. See contract level note for further details. This may only be called by governance or the guardian.    
 
 
 
@@ -366,7 +366,7 @@ function setWithdrawalQueue(address[20])
 ```
 
 
-@notice Updates the withdrawalQueue to match the addresses and order specified by `queue`. There can be fewer strategies than the maximum, as well as fewer than the total number of strategies active in the vault. `withdrawalQueue` will be updated in a gas-efficient manner, assuming the input is well- ordered with 0x0 only at the end. This may only be called by governance or management.    
+Updates the withdrawalQueue to match the addresses and order specified by `queue`. There can be fewer strategies than the maximum, as well as fewer than the total number of strategies active in the vault. `withdrawalQueue` will be updated in a gas-efficient manner, assuming the input is well- ordered with 0x0 only at the end. This may only be called by governance or management.    
 
 
 *This is order sensitive, specify the addresses in the order in which funds should be withdrawn (so `queue`[0] is the first Strategy withdrawn from, `queue`[1] is the second, etc.) This means that the least impactful Strategy (the Strategy that will have its core positions impacted the least by having funds removed) should be at `queue`[0], then the next least impactful at `queue`[1], and so on.*
@@ -389,7 +389,7 @@ function transfer(address,uint256)
 ```
 
 
-@notice Transfers shares from the caller&#39;s address to `receiver`. This function will always return true, unless the user is attempting to transfer shares to this contract&#39;s address, or to 0x0.    
+Transfers shares from the caller&#39;s address to `receiver`. This function will always return true, unless the user is attempting to transfer shares to this contract&#39;s address, or to 0x0.    
 
 
 
@@ -417,7 +417,7 @@ function transferFrom(address,address,uint256)
 ```
 
 
-@notice Transfers `amount` shares from `sender` to `receiver`. This operation will always return true, unless the user is attempting to transfer shares to this contract&#39;s address, or to 0x0. Unless the caller has given this contract unlimited approval, transfering shares will decrement the caller&#39;s `allowance` by `amount`.    
+Transfers `amount` shares from `sender` to `receiver`. This operation will always return true, unless the user is attempting to transfer shares to this contract&#39;s address, or to 0x0. Unless the caller has given this contract unlimited approval, transfering shares will decrement the caller&#39;s `allowance` by `amount`.    
 
 
 
@@ -512,7 +512,7 @@ function permit(address,address,uint256,uint256,bytes)
 ```
 
 
-@notice Approves spender by owner&#39;s signature to expend owner&#39;s tokens. See https://eips.ethereum.org/EIPS/eip-2612.    
+Approves spender by owner&#39;s signature to expend owner&#39;s tokens. See https://eips.ethereum.org/EIPS/eip-2612.    
 
 
 
@@ -543,7 +543,7 @@ function totalAssets()
 ```
 
 
-@notice Returns the total quantity of all assets under control of this Vault, whether they&#39;re loaned out to a Strategy, or currently held in the Vault.    
+Returns the total quantity of all assets under control of this Vault, whether they&#39;re loaned out to a Strategy, or currently held in the Vault.    
 
 
 
@@ -564,7 +564,7 @@ function deposit()
 ```
 
 
-@notice Deposits `_amount` `token`, issuing shares to `recipient`. If the Vault is in Emergency Shutdown, deposits will not be accepted and this call will fail.    
+Deposits `_amount` `token`, issuing shares to `recipient`. If the Vault is in Emergency Shutdown, deposits will not be accepted and this call will fail.    
 
 
 *Measuring quantity of shares to issues is based on the total outstanding debt that this contract has (&#34;expected value&#34;) instead of the total balance sheet it has (&#34;estimated value&#34;) has important security considerations, and is done intentionally. If this value were measured against external systems, it could be purposely manipulated by an attacker to withdraw more assets than they otherwise should be able to claim by redeeming their shares. On deposit, this means that shares are issued against the total amount that the deposited capital can be given in service of the debt that Strategies assume. If that number were to be lower than the &#34;expected value&#34; at some future point, depositing shares via this method could entitle the depositor to *less* than the deposited value once the &#34;realized value&#34; is updated from further reports by the Strategies to the Vaults. Care should be taken by integrators to account for this discrepancy, by using the view-only methods of this contract (both off-chain and on-chain) to determine if depositing into the Vault is a &#34;good idea&#34;.*
@@ -650,7 +650,7 @@ function maxAvailableShares()
 ```
 
 
-@notice Determines the maximum quantity of shares this Vault can facilitate a withdrawal for, factoring in assets currently residing in the Vault, as well as those deployed to strategies on the Vault&#39;s balance sheet.    
+Determines the maximum quantity of shares this Vault can facilitate a withdrawal for, factoring in assets currently residing in the Vault, as well as those deployed to strategies on the Vault&#39;s balance sheet.    
 
 
 *Regarding how shares are calculated, see dev note on `deposit`. If you want to calculated the maximum a user could withdraw up to, you want to use this function. Note that the amount provided by this function is the theoretical maximum possible from withdrawing, the real amount depends on the realized losses incurred during withdrawal.*
@@ -673,7 +673,7 @@ function withdraw()
 ```
 
 
-@notice Withdraws the calling account&#39;s tokens from this Vault, redeeming amount `_shares` for an appropriate amount of tokens. See note on `setWithdrawalQueue` for further details of withdrawal ordering and behavior.    
+Withdraws the calling account&#39;s tokens from this Vault, redeeming amount `_shares` for an appropriate amount of tokens. See note on `setWithdrawalQueue` for further details of withdrawal ordering and behavior.    
 
 
 *Measuring the value of shares is based on the total outstanding debt that this contract has (&#34;expected value&#34;) instead of the total balance sheet it has (&#34;estimated value&#34;) has important security considerations, and is done intentionally. If this value were measured against external systems, it could be purposely manipulated by an attacker to withdraw more assets than they otherwise should be able to claim by redeeming their shares. On withdrawal, this means that shares are redeemed against the total amount that the deposited capital had &#34;realized&#34; since the point it was deposited, up until the point it was withdrawn. If that number were to be higher than the &#34;expected value&#34; at some future point, withdrawing shares via this method could entitle the depositor to *more* than the expected value once the &#34;realized value&#34; is updated from further reports by the Strategies to the Vaults. Under exceptional scenarios, this could cause earlier withdrawals to earn &#34;more&#34; of the underlying assets than Users might otherwise be entitled to, if the Vault&#39;s estimated value were otherwise measured through external means, accounting for whatever exceptional scenarios exist for the Vault (that aren&#39;t covered by the Vault&#39;s own design.)*
@@ -791,7 +791,7 @@ function pricePerShare()
 ```
 
 
-@notice Gives the price for a single Vault share.    
+Gives the price for a single Vault share.    
 
 
 *See dev note on `withdraw`.*
@@ -814,7 +814,7 @@ function addStrategy(address,uint256,uint256,uint256,uint256)
 ```
 
 
-@notice Add a Strategy to the Vault. This may only be called by governance.    
+Add a Strategy to the Vault. This may only be called by governance.    
 
 
 *The Strategy will be appended to `withdrawalQueue`, call `setWithdrawalQueue` to change the order.*
@@ -841,7 +841,7 @@ function updateStrategyDebtRatio(address,uint256)
 ```
 
 
-@notice Change the quantity of assets `strategy` may manage. This may be called by governance or management.    
+Change the quantity of assets `strategy` may manage. This may be called by governance or management.    
 
 
 
@@ -863,7 +863,7 @@ function updateStrategyMinDebtPerHarvest(address,uint256)
 ```
 
 
-@notice Change the quantity assets per block this Vault may deposit to or withdraw from `strategy`. This may only be called by governance or management.    
+Change the quantity assets per block this Vault may deposit to or withdraw from `strategy`. This may only be called by governance or management.    
 
 
 
@@ -885,7 +885,7 @@ function updateStrategyMaxDebtPerHarvest(address,uint256)
 ```
 
 
-@notice Change the quantity assets per block this Vault may deposit to or withdraw from `strategy`. This may only be called by governance or management.    
+Change the quantity assets per block this Vault may deposit to or withdraw from `strategy`. This may only be called by governance or management.    
 
 
 
@@ -907,7 +907,7 @@ function updateStrategyPerformanceFee(address,uint256)
 ```
 
 
-@notice Change the fee the strategist will receive based on this Vault&#39;s performance. This may only be called by governance.    
+Change the fee the strategist will receive based on this Vault&#39;s performance. This may only be called by governance.    
 
 
 
@@ -929,7 +929,7 @@ function migrateStrategy(address,address)
 ```
 
 
-@notice Migrates a Strategy, including all assets from `oldVersion` to `newVersion`. This may only be called by governance.    
+Migrates a Strategy, including all assets from `oldVersion` to `newVersion`. This may only be called by governance.    
 
 
 *Strategy must successfully migrate all capital and positions to new Strategy, or else this will upset the balance of the Vault. The new Strategy should be &#34;empty&#34; e.g. have no prior commitments to this Vault, otherwise it could have issues.*
@@ -953,7 +953,7 @@ function revokeStrategy()
 ```
 
 
-@notice Revoke a Strategy, setting its debt limit to 0 and preventing any future deposits. This function should only be used in the scenario where the Strategy is being retired but no migration of the positions are possible, or in the extreme scenario that the Strategy needs to be put into &#34;Emergency Exit&#34; mode in order for it to exit as quickly as possible. The latter scenario could be for any reason that is considered &#34;critical&#34; that the Strategy exits its position as fast as possible, such as a sudden change in market conditions leading to losses, or an imminent failure in an external dependency. This may only be called by governance, the guardian, or the Strategy itself. Note that a Strategy will only revoke itself during emergency shutdown.    
+Revoke a Strategy, setting its debt limit to 0 and preventing any future deposits. This function should only be used in the scenario where the Strategy is being retired but no migration of the positions are possible, or in the extreme scenario that the Strategy needs to be put into &#34;Emergency Exit&#34; mode in order for it to exit as quickly as possible. The latter scenario could be for any reason that is considered &#34;critical&#34; that the Strategy exits its position as fast as possible, such as a sudden change in market conditions leading to losses, or an imminent failure in an external dependency. This may only be called by governance, the guardian, or the Strategy itself. Note that a Strategy will only revoke itself during emergency shutdown.    
 
 
 
@@ -993,7 +993,7 @@ function addStrategyToQueue(address)
 ```
 
 
-@notice Adds `strategy` to `withdrawalQueue`. This may only be called by governance or management.    
+Adds `strategy` to `withdrawalQueue`. This may only be called by governance or management.    
 
 
 *The Strategy will be appended to `withdrawalQueue`, call `setWithdrawalQueue` to change the order.*
@@ -1016,7 +1016,7 @@ function removeStrategyFromQueue(address)
 ```
 
 
-@notice Remove `strategy` from `withdrawalQueue`. This may only be called by governance or management.    
+Remove `strategy` from `withdrawalQueue`. This may only be called by governance or management.    
 
 
 *We don&#39;t do this with revokeStrategy because it should still be possible to withdraw from the Strategy if it&#39;s unwinding.*
@@ -1039,7 +1039,7 @@ function debtOutstanding()
 ```
 
 
-@notice Determines if `strategy` is past its debt limit and if any tokens should be withdrawn to the Vault.    
+Determines if `strategy` is past its debt limit and if any tokens should be withdrawn to the Vault.    
 
 
 
@@ -1091,7 +1091,7 @@ function creditAvailable()
 ```
 
 
-@notice Amount of tokens in Vault a Strategy has access to as a credit line. This will check the Strategy&#39;s debt limit, as well as the tokens available in the Vault, and determine the maximum amount of tokens (if any) the Strategy may draw on. In the rare case the Vault is in emergency shutdown this will return 0.    
+Amount of tokens in Vault a Strategy has access to as a credit line. This will check the Strategy&#39;s debt limit, as well as the tokens available in the Vault, and determine the maximum amount of tokens (if any) the Strategy may draw on. In the rare case the Vault is in emergency shutdown this will return 0.    
 
 
 
@@ -1143,7 +1143,7 @@ function expectedReturn()
 ```
 
 
-@notice Provide an accurate expected value for the return this `strategy` would provide to the Vault the next time `report()` is called (since the last time it was called).    
+Provide an accurate expected value for the return this `strategy` would provide to the Vault the next time `report()` is called (since the last time it was called).    
 
 
 
@@ -1195,7 +1195,7 @@ function report(uint256,uint256,uint256)
 ```
 
 
-@notice Reports the amount of assets the calling Strategy has free (usually in terms of ROI). The performance fee is determined here, off of the strategy&#39;s profits (if any), and sent to governance. The strategist&#39;s fee is also determined here (off of profits), to be handled according to the strategist on the next harvest. This may only be called by a Strategy managed by this Vault.    
+Reports the amount of assets the calling Strategy has free (usually in terms of ROI). The performance fee is determined here, off of the strategy&#39;s profits (if any), and sent to governance. The strategist&#39;s fee is also determined here (off of profits), to be handled according to the strategist on the next harvest. This may only be called by a Strategy managed by this Vault.    
 
 
 *For approved strategies, this is the most efficient behavior. The Strategy reports back what it has free, then Vault &#34;decides&#34; whether to take some back or give it more. Note that the most it can take is `gain + _debtPayment`, and the most it can give is all of the remaining reserves. Anything outside of those bounds is abnormal behavior. All approved strategies must have increased diligence around calling this function, as abnormal behavior could become catastrophic.*
@@ -1226,7 +1226,7 @@ function sweep(address)
 ```
 
 
-@notice Removes tokens from this Vault that are not the type of token managed by this Vault. This may be used in case of accidentally sending the wrong kind of token to this Vault. Tokens will be sent to `governance`. This will fail if an attempt is made to sweep the tokens that this Vault manages. This may only be called by governance.    
+Removes tokens from this Vault that are not the type of token managed by this Vault. This may be used in case of accidentally sending the wrong kind of token to this Vault. Tokens will be sent to `governance`. This will fail if an attempt is made to sweep the tokens that this Vault manages. This may only be called by governance.    
 
 
 

--- a/versioned_docs/version-0.3.3/smart-contracts/BaseStrategy.md
+++ b/versioned_docs/version-0.3.3/smart-contracts/BaseStrategy.md
@@ -8,7 +8,7 @@
   function apiVersion(
   ) public returns (string)
 ```
-@notice
+
  Used to track which version of `StrategyAPI` this Strategy
  implements.
 
@@ -41,7 +41,7 @@ This Strategy's name.
   function delegatedAssets(
   ) external returns (uint256)
 ```
-@notice
+
  The amount (priced in want) of the total assets managed by this strategy should not count
  towards Yearn's TVL calculations.
 @dev
@@ -70,7 +70,7 @@ This Strategy's name.
     address _vault
   ) internal
 ```
-@notice
+
  Initializes the Strategy, this is called only once, when the
  contract is deployed.
 
@@ -87,7 +87,7 @@ This Strategy's name.
     address _strategist
   ) external
 ```
-@notice
+
  Used to change `strategist`.
 
  This may only be called by governance or the existing strategist.
@@ -104,7 +104,7 @@ This Strategy's name.
     address _keeper
   ) external
 ```
-@notice
+
  Used to change `keeper`.
 
  `keeper` is the only address that may call `tend()` or `harvest()`,
@@ -127,7 +127,7 @@ This Strategy's name.
     address _rewards
   ) external
 ```
-@notice
+
  Used to change `rewards`. EOA or smart contract which has the permission
  to pull rewards from the vault.
 
@@ -145,7 +145,7 @@ This Strategy's name.
     uint256 _delay
   ) external
 ```
-@notice
+
  Used to change `minReportDelay`. `minReportDelay` is the minimum number
  of blocks that should pass for `harvest()` to be called.
 
@@ -167,7 +167,7 @@ This Strategy's name.
     uint256 _delay
   ) external
 ```
-@notice
+
  Used to change `maxReportDelay`. `maxReportDelay` is the maximum number
  of blocks that should pass for `harvest()` to be called.
 
@@ -189,7 +189,7 @@ This Strategy's name.
     uint256 _profitFactor
   ) external
 ```
-@notice
+
  Used to change `profitFactor`. `profitFactor` is used to determine
  if it's worthwhile to harvest, given gas costs. (See `harvestTrigger()`
  for more details.)
@@ -209,7 +209,7 @@ This Strategy's name.
     uint256 _debtThreshold
   ) external
 ```
-@notice
+
  Sets how far the Strategy can go into loss without a harvest and report
  being required.
 
@@ -232,7 +232,7 @@ being required to report to the Vault.
     string _metadataURI
   ) external
 ```
-@notice
+
  Used to change `metadataURI`. `metadataURI` is used to store the URI
 of the file describing the strategy.
 
@@ -259,7 +259,7 @@ on protected functions in the Strategy.
   function estimatedTotalAssets(
   ) public returns (uint256)
 ```
-@notice
+
  Provide an accurate estimate for the total amount of assets
  (principle + return) that this Strategy is currently managing,
  denominated in terms of `want` tokens.
@@ -365,7 +365,7 @@ NOTE: The invariant `_liquidatedAmount + _loss <= _amountNeeded` should always b
     uint256 callCost
   ) public returns (bool)
 ```
-@notice
+
  Provide a signal to the keeper that `tend()` should be called. The
  keeper will provide the estimated gas cost that they would pay to call
  `tend()`, and this function should use that estimate to make a
@@ -395,7 +395,7 @@ NOTE: The invariant `_liquidatedAmount + _loss <= _amountNeeded` should always b
   function tend(
   ) external
 ```
-@notice
+
  Adjust the Strategy's position. The purpose of tending isn't to
  realize gains, but to maximize yield by reinvesting any returns.
 
@@ -411,7 +411,7 @@ NOTE: The invariant `_liquidatedAmount + _loss <= _amountNeeded` should always b
     uint256 callCost
   ) public returns (bool)
 ```
-@notice
+
  Provide a signal to the keeper that `harvest()` should be called. The
  keeper will provide the estimated gas cost that they would pay to call
  `harvest()`, and this function should use that estimate to make a
@@ -453,7 +453,7 @@ NOTE: The invariant `_liquidatedAmount + _loss <= _amountNeeded` should always b
   function harvest(
   ) external
 ```
-@notice
+
  Harvests the Strategy, recognizing any profits or losses and adjusting
  the Strategy's position.
 
@@ -477,7 +477,7 @@ NOTE: The invariant `_liquidatedAmount + _loss <= _amountNeeded` should always b
     uint256 _amountNeeded
   ) external returns (uint256 _loss)
 ```
-@notice
+
  Withdraws `_amountNeeded` to `vault`.
 
  This may only be called by the Vault.
@@ -509,7 +509,7 @@ value.
     address _newStrategy
   ) external
 ```
-@notice
+
  Transfers all `want` from this Strategy to `_newStrategy`.
 
  This may only be called by governance or the Vault.
@@ -527,7 +527,7 @@ value.
   function setEmergencyExit(
   ) external
 ```
-@notice
+
  Activates emergency exit. Once activated, the Strategy will exit its
  position upon the next harvest, depositing all funds into the Vault as
  quickly as is reasonable given on-chain conditions.
@@ -567,7 +567,7 @@ Example:
     address _token
   ) external
 ```
-@notice
+
  Removes tokens from this Strategy that are not the type of tokens
  managed by this Strategy. This may be used in case of accidentally
  sending the wrong kind of token to this Strategy.

--- a/versioned_docs/version-0.3.3/smart-contracts/registry.md
+++ b/versioned_docs/version-0.3.3/smart-contracts/registry.md
@@ -16,7 +16,7 @@ function setGovernance(address)
 ```
 
 
-@notice Starts the 1st phase of the governance transfer.    
+Starts the 1st phase of the governance transfer.    
 
 
 *Throws if the caller is not current governance.*
@@ -39,7 +39,7 @@ function acceptGovernance()
 ```
 
 
-@notice Completes the 2nd phase of the governance transfer.    
+Completes the 2nd phase of the governance transfer.    
 
 
 *Throws if the caller is not the pending caller. Emits a `NewGovernance` event.*
@@ -56,7 +56,7 @@ function latestRelease()
 ```
 
 
-@notice Returns the api version of the latest release.    
+Returns the api version of the latest release.    
 
 
 *Throws if no releases are registered yet.*
@@ -79,7 +79,7 @@ function latestVault(address)
 ```
 
 
-@notice Returns the latest deployed vault for the given token.    
+Returns the latest deployed vault for the given token.    
 
 
 *Throws if no vaults are endorsed yet for the given token.*
@@ -108,7 +108,7 @@ function newRelease(address)
 ```
 
 
-@notice Add a previously deployed Vault as the template contract for the latest release, to be used by further &#34;forwarder-style&#34; delegatecall proxy contracts that can be deployed from the registry throw other methods (to save gas).    
+Add a previously deployed Vault as the template contract for the latest release, to be used by further &#34;forwarder-style&#34; delegatecall proxy contracts that can be deployed from the registry throw other methods (to save gas).    
 
 
 *Throws if caller isn&#39;t `self.governance`. Throws if `vault`&#39;s governance isn&#39;t `self.governance`. Throws if the api version is the same as the previous release. Emits a `NewVault` event.*
@@ -131,7 +131,7 @@ function newVault(address,address,address,string,string)
 ```
 
 
-@notice Create a new vault for the given token using the latest release in the registry, as a simple &#34;forwarder-style&#34; delegatecall proxy to the latest release. Also adds the new vault to the list of &#34;endorsed&#34; vaults for that token.    
+Create a new vault for the given token using the latest release in the registry, as a simple &#34;forwarder-style&#34; delegatecall proxy to the latest release. Also adds the new vault to the list of &#34;endorsed&#34; vaults for that token.    
 
 
 *`governance` is set in the new vault as `self.governance`, with no ability to override. Throws if caller isn&#39;t `self.governance`. Throws if no releases are registered yet. Throws if there already is a registered vault for the given token with the latest api version. Emits a `NewVault` event.*
@@ -197,7 +197,7 @@ function newExperimentalVault(address,address,address,address,string,string)
 ```
 
 
-@notice Create a new vault for the given token using the latest release in the registry, as a simple &#34;forwarder-style&#34; delegatecall proxy to the latest release. Does not add the new vault to the list of &#34;endorsed&#34; vaults for that token.    
+Create a new vault for the given token using the latest release in the registry, as a simple &#34;forwarder-style&#34; delegatecall proxy to the latest release. Does not add the new vault to the list of &#34;endorsed&#34; vaults for that token.    
 
 
 *Throws if no releases are registered yet. Emits a `NewExperimentalVault` event.*
@@ -265,7 +265,7 @@ function endorseVault(address)
 ```
 
 
-@notice Adds an existing vault to the list of &#34;endorsed&#34; vaults for that token.    
+Adds an existing vault to the list of &#34;endorsed&#34; vaults for that token.    
 
 
 *`governance` is set in the new vault as `self.governance`, with no ability to override. Throws if caller isn&#39;t `self.governance`. Throws if `vault`&#39;s governance isn&#39;t `self.governance`. Throws if no releases are registered yet. Throws if `vault`&#39;s api version does not match latest release. Throws if there already is a deployment for the vault&#39;s token with the latest api version. Emits a `NewVault` event.*
@@ -311,7 +311,7 @@ function setBanksy(address)
 ```
 
 
-@notice Set the ability of a particular tagger to tag current vaults.    
+Set the ability of a particular tagger to tag current vaults.    
 
 
 *Throws if caller is not `self.governance`.*
@@ -357,7 +357,7 @@ function tagVault(address,string)
 ```
 
 
-@notice Tag a Vault with a message.    
+Tag a Vault with a message.    
 
 
 *Throws if caller is not `self.governance` or an approved tagger. Emits a `VaultTagged` event.*

--- a/versioned_docs/version-0.3.3/smart-contracts/vault.md
+++ b/versioned_docs/version-0.3.3/smart-contracts/vault.md
@@ -20,7 +20,7 @@ function initialize(address,address,address,string,string)
 ```
 
 
-@notice Initializes the Vault, this is called only once, when the contract is deployed. The performance fee is set to 10% of yield, per Strategy. The management fee is set to 2%, per year. The initial deposit limit is set to 0 (deposits disabled); it must be updated after initialization.    
+Initializes the Vault, this is called only once, when the contract is deployed. The performance fee is set to 10% of yield, per Strategy. The management fee is set to 2%, per year. The initial deposit limit is set to 0 (deposits disabled); it must be updated after initialization.    
 
 
 *If `nameOverride` is not specified, the name will be &#39;yearn&#39; combined with the name of `token`. If `symbolOverride` is not specified, the symbol will be &#39;y&#39; combined with the symbol of `token`.*
@@ -74,7 +74,7 @@ function apiVersion()
 ```
 
 
-@notice Used to track the deployed version of this contract. In practice you can use this version number to compare with Yearn&#39;s GitHub and determine which version of the source matches this deployed contract.    
+Used to track the deployed version of this contract. In practice you can use this version number to compare with Yearn&#39;s GitHub and determine which version of the source matches this deployed contract.    
 
 
 *All strategies must have an `apiVersion()` that matches the Vault&#39;s `API_VERSION`.*
@@ -97,7 +97,7 @@ function setName(string)
 ```
 
 
-@notice Used to change the value of `name`. This may only be called by governance.    
+Used to change the value of `name`. This may only be called by governance.    
 
 
 
@@ -118,7 +118,7 @@ function setSymbol(string)
 ```
 
 
-@notice Used to change the value of `symbol`. This may only be called by governance.    
+Used to change the value of `symbol`. This may only be called by governance.    
 
 
 
@@ -139,7 +139,7 @@ function setGovernance(address)
 ```
 
 
-@notice Nominate a new address to use as governance. The change does not go into effect immediately. This function sets a pending change, and the governance address is not updated until the proposed governance address has accepted the responsibility. This may only be called by the current governance address.    
+Nominate a new address to use as governance. The change does not go into effect immediately. This function sets a pending change, and the governance address is not updated until the proposed governance address has accepted the responsibility. This may only be called by the current governance address.    
 
 
 
@@ -160,7 +160,7 @@ function acceptGovernance()
 ```
 
 
-@notice Once a new governance address has been proposed using setGovernance(), this function may be called by the proposed address to accept the responsibility of taking over governance for this contract. This may only be called by the proposed governance address.    
+Once a new governance address has been proposed using setGovernance(), this function may be called by the proposed address to accept the responsibility of taking over governance for this contract. This may only be called by the proposed governance address.    
 
 
 *setGovernance() should be called by the existing governance address, prior to calling this function.*
@@ -177,7 +177,7 @@ function setManagement(address)
 ```
 
 
-@notice Changes the management address. Management is able to make some investment decisions adjusting parameters. This may only be called by governance.    
+Changes the management address. Management is able to make some investment decisions adjusting parameters. This may only be called by governance.    
 
 
 
@@ -198,7 +198,7 @@ function setGuestList(address)
 ```
 
 
-@notice Used to set or change `guestList`. A guest list is another contract that dictates who is allowed to participate in a Vault (and transfer shares). This may only be called by governance.    
+Used to set or change `guestList`. A guest list is another contract that dictates who is allowed to participate in a Vault (and transfer shares). This may only be called by governance.    
 
 
 
@@ -219,7 +219,7 @@ function setRewards(address)
 ```
 
 
-@notice Changes the rewards address. Any distributed rewards will cease flowing to the old address and begin flowing to this address once the change is in effect. This will not change any Strategy reports in progress, only new reports made after this change goes into effect. This may only be called by governance.    
+Changes the rewards address. Any distributed rewards will cease flowing to the old address and begin flowing to this address once the change is in effect. This will not change any Strategy reports in progress, only new reports made after this change goes into effect. This may only be called by governance.    
 
 
 
@@ -240,7 +240,7 @@ function setLockedProfitDegration(uint256)
 ```
 
 
-@notice Changes the locked profit degration.    
+Changes the locked profit degration.    
 
 
 
@@ -261,7 +261,7 @@ function setDepositLimit(uint256)
 ```
 
 
-@notice Changes the maximum amount of tokens that can be deposited in this Vault. Note, this is not how much may be deposited by a single depositor, but the maximum amount that may be deposited across all depositors. This may only be called by governance.    
+Changes the maximum amount of tokens that can be deposited in this Vault. Note, this is not how much may be deposited by a single depositor, but the maximum amount that may be deposited across all depositors. This may only be called by governance.    
 
 
 
@@ -282,7 +282,7 @@ function setPerformanceFee(uint256)
 ```
 
 
-@notice Used to change the value of `performanceFee`. Should set this value below the maximum strategist performance fee. This may only be called by governance.    
+Used to change the value of `performanceFee`. Should set this value below the maximum strategist performance fee. This may only be called by governance.    
 
 
 
@@ -303,7 +303,7 @@ function setManagementFee(uint256)
 ```
 
 
-@notice Used to change the value of `managementFee`. This may only be called by governance.    
+Used to change the value of `managementFee`. This may only be called by governance.    
 
 
 
@@ -324,7 +324,7 @@ function setGuardian(address)
 ```
 
 
-@notice Used to change the address of `guardian`. This may only be called by governance or the existing guardian.    
+Used to change the address of `guardian`. This may only be called by governance or the existing guardian.    
 
 
 
@@ -345,7 +345,7 @@ function setEmergencyShutdown(bool)
 ```
 
 
-@notice Activates or deactivates Vault mode where all Strategies go into full withdrawal. During Emergency Shutdown: 1. No Users may deposit into the Vault (but may withdraw as usual.) 2. Governance may not add new Strategies. 3. Each Strategy must pay back their debt as quickly as reasonable to minimally affect their position. 4. Only Governance may undo Emergency Shutdown. See contract level note for further details. This may only be called by governance or the guardian.    
+Activates or deactivates Vault mode where all Strategies go into full withdrawal. During Emergency Shutdown: 1. No Users may deposit into the Vault (but may withdraw as usual.) 2. Governance may not add new Strategies. 3. Each Strategy must pay back their debt as quickly as reasonable to minimally affect their position. 4. Only Governance may undo Emergency Shutdown. See contract level note for further details. This may only be called by governance or the guardian.    
 
 
 
@@ -366,7 +366,7 @@ function setWithdrawalQueue(address[20])
 ```
 
 
-@notice Updates the withdrawalQueue to match the addresses and order specified by `queue`. There can be fewer strategies than the maximum, as well as fewer than the total number of strategies active in the vault. `withdrawalQueue` will be updated in a gas-efficient manner, assuming the input is well- ordered with 0x0 only at the end. This may only be called by governance or management.    
+Updates the withdrawalQueue to match the addresses and order specified by `queue`. There can be fewer strategies than the maximum, as well as fewer than the total number of strategies active in the vault. `withdrawalQueue` will be updated in a gas-efficient manner, assuming the input is well- ordered with 0x0 only at the end. This may only be called by governance or management.    
 
 
 *This is order sensitive, specify the addresses in the order in which funds should be withdrawn (so `queue`[0] is the first Strategy withdrawn from, `queue`[1] is the second, etc.) This means that the least impactful Strategy (the Strategy that will have its core positions impacted the least by having funds removed) should be at `queue`[0], then the next least impactful at `queue`[1], and so on.*
@@ -389,7 +389,7 @@ function transfer(address,uint256)
 ```
 
 
-@notice Transfers shares from the caller&#39;s address to `receiver`. This function will always return true, unless the user is attempting to transfer shares to this contract&#39;s address, or to 0x0.    
+Transfers shares from the caller&#39;s address to `receiver`. This function will always return true, unless the user is attempting to transfer shares to this contract&#39;s address, or to 0x0.    
 
 
 
@@ -417,7 +417,7 @@ function transferFrom(address,address,uint256)
 ```
 
 
-@notice Transfers `amount` shares from `sender` to `receiver`. This operation will always return true, unless the user is attempting to transfer shares to this contract&#39;s address, or to 0x0. Unless the caller has given this contract unlimited approval, transfering shares will decrement the caller&#39;s `allowance` by `amount`.    
+Transfers `amount` shares from `sender` to `receiver`. This operation will always return true, unless the user is attempting to transfer shares to this contract&#39;s address, or to 0x0. Unless the caller has given this contract unlimited approval, transfering shares will decrement the caller&#39;s `allowance` by `amount`.    
 
 
 
@@ -512,7 +512,7 @@ function permit(address,address,uint256,uint256,bytes)
 ```
 
 
-@notice Approves spender by owner&#39;s signature to expend owner&#39;s tokens. See https://eips.ethereum.org/EIPS/eip-2612.    
+Approves spender by owner&#39;s signature to expend owner&#39;s tokens. See https://eips.ethereum.org/EIPS/eip-2612.    
 
 
 
@@ -543,7 +543,7 @@ function totalAssets()
 ```
 
 
-@notice Returns the total quantity of all assets under control of this Vault, whether they&#39;re loaned out to a Strategy, or currently held in the Vault.    
+Returns the total quantity of all assets under control of this Vault, whether they&#39;re loaned out to a Strategy, or currently held in the Vault.    
 
 
 
@@ -564,7 +564,7 @@ function deposit()
 ```
 
 
-@notice Deposits `_amount` `token`, issuing shares to `recipient`. If the Vault is in Emergency Shutdown, deposits will not be accepted and this call will fail.    
+Deposits `_amount` `token`, issuing shares to `recipient`. If the Vault is in Emergency Shutdown, deposits will not be accepted and this call will fail.    
 
 
 *Measuring quantity of shares to issues is based on the total outstanding debt that this contract has (&#34;expected value&#34;) instead of the total balance sheet it has (&#34;estimated value&#34;) has important security considerations, and is done intentionally. If this value were measured against external systems, it could be purposely manipulated by an attacker to withdraw more assets than they otherwise should be able to claim by redeeming their shares. On deposit, this means that shares are issued against the total amount that the deposited capital can be given in service of the debt that Strategies assume. If that number were to be lower than the &#34;expected value&#34; at some future point, depositing shares via this method could entitle the depositor to *less* than the deposited value once the &#34;realized value&#34; is updated from further reports by the Strategies to the Vaults. Care should be taken by integrators to account for this discrepancy, by using the view-only methods of this contract (both off-chain and on-chain) to determine if depositing into the Vault is a &#34;good idea&#34;.*
@@ -650,7 +650,7 @@ function maxAvailableShares()
 ```
 
 
-@notice Determines the maximum quantity of shares this Vault can facilitate a withdrawal for, factoring in assets currently residing in the Vault, as well as those deployed to strategies on the Vault&#39;s balance sheet.    
+Determines the maximum quantity of shares this Vault can facilitate a withdrawal for, factoring in assets currently residing in the Vault, as well as those deployed to strategies on the Vault&#39;s balance sheet.    
 
 
 *Regarding how shares are calculated, see dev note on `deposit`. If you want to calculated the maximum a user could withdraw up to, you want to use this function. Note that the amount provided by this function is the theoretical maximum possible from withdrawing, the real amount depends on the realized losses incurred during withdrawal.*
@@ -673,7 +673,7 @@ function withdraw()
 ```
 
 
-@notice Withdraws the calling account&#39;s tokens from this Vault, redeeming amount `_shares` for an appropriate amount of tokens. See note on `setWithdrawalQueue` for further details of withdrawal ordering and behavior.    
+Withdraws the calling account&#39;s tokens from this Vault, redeeming amount `_shares` for an appropriate amount of tokens. See note on `setWithdrawalQueue` for further details of withdrawal ordering and behavior.    
 
 
 *Measuring the value of shares is based on the total outstanding debt that this contract has (&#34;expected value&#34;) instead of the total balance sheet it has (&#34;estimated value&#34;) has important security considerations, and is done intentionally. If this value were measured against external systems, it could be purposely manipulated by an attacker to withdraw more assets than they otherwise should be able to claim by redeeming their shares. On withdrawal, this means that shares are redeemed against the total amount that the deposited capital had &#34;realized&#34; since the point it was deposited, up until the point it was withdrawn. If that number were to be higher than the &#34;expected value&#34; at some future point, withdrawing shares via this method could entitle the depositor to *more* than the expected value once the &#34;realized value&#34; is updated from further reports by the Strategies to the Vaults. Under exceptional scenarios, this could cause earlier withdrawals to earn &#34;more&#34; of the underlying assets than Users might otherwise be entitled to, if the Vault&#39;s estimated value were otherwise measured through external means, accounting for whatever exceptional scenarios exist for the Vault (that aren&#39;t covered by the Vault&#39;s own design.)*
@@ -791,7 +791,7 @@ function pricePerShare()
 ```
 
 
-@notice Gives the price for a single Vault share.    
+Gives the price for a single Vault share.    
 
 
 *See dev note on `withdraw`.*
@@ -814,7 +814,7 @@ function addStrategy(address,uint256,uint256,uint256,uint256)
 ```
 
 
-@notice Add a Strategy to the Vault. This may only be called by governance.    
+Add a Strategy to the Vault. This may only be called by governance.    
 
 
 *The Strategy will be appended to `withdrawalQueue`, call `setWithdrawalQueue` to change the order.*
@@ -841,7 +841,7 @@ function updateStrategyDebtRatio(address,uint256)
 ```
 
 
-@notice Change the quantity of assets `strategy` may manage. This may be called by governance or management.    
+Change the quantity of assets `strategy` may manage. This may be called by governance or management.    
 
 
 
@@ -863,7 +863,7 @@ function updateStrategyMinDebtPerHarvest(address,uint256)
 ```
 
 
-@notice Change the quantity assets per block this Vault may deposit to or withdraw from `strategy`. This may only be called by governance or management.    
+Change the quantity assets per block this Vault may deposit to or withdraw from `strategy`. This may only be called by governance or management.    
 
 
 
@@ -885,7 +885,7 @@ function updateStrategyMaxDebtPerHarvest(address,uint256)
 ```
 
 
-@notice Change the quantity assets per block this Vault may deposit to or withdraw from `strategy`. This may only be called by governance or management.    
+Change the quantity assets per block this Vault may deposit to or withdraw from `strategy`. This may only be called by governance or management.    
 
 
 
@@ -907,7 +907,7 @@ function updateStrategyPerformanceFee(address,uint256)
 ```
 
 
-@notice Change the fee the strategist will receive based on this Vault&#39;s performance. This may only be called by governance.    
+Change the fee the strategist will receive based on this Vault&#39;s performance. This may only be called by governance.    
 
 
 
@@ -929,7 +929,7 @@ function migrateStrategy(address,address)
 ```
 
 
-@notice Migrates a Strategy, including all assets from `oldVersion` to `newVersion`. This may only be called by governance.    
+Migrates a Strategy, including all assets from `oldVersion` to `newVersion`. This may only be called by governance.    
 
 
 *Strategy must successfully migrate all capital and positions to new Strategy, or else this will upset the balance of the Vault. The new Strategy should be &#34;empty&#34; e.g. have no prior commitments to this Vault, otherwise it could have issues.*
@@ -953,7 +953,7 @@ function revokeStrategy()
 ```
 
 
-@notice Revoke a Strategy, setting its debt limit to 0 and preventing any future deposits. This function should only be used in the scenario where the Strategy is being retired but no migration of the positions are possible, or in the extreme scenario that the Strategy needs to be put into &#34;Emergency Exit&#34; mode in order for it to exit as quickly as possible. The latter scenario could be for any reason that is considered &#34;critical&#34; that the Strategy exits its position as fast as possible, such as a sudden change in market conditions leading to losses, or an imminent failure in an external dependency. This may only be called by governance, the guardian, or the Strategy itself. Note that a Strategy will only revoke itself during emergency shutdown.    
+Revoke a Strategy, setting its debt limit to 0 and preventing any future deposits. This function should only be used in the scenario where the Strategy is being retired but no migration of the positions are possible, or in the extreme scenario that the Strategy needs to be put into &#34;Emergency Exit&#34; mode in order for it to exit as quickly as possible. The latter scenario could be for any reason that is considered &#34;critical&#34; that the Strategy exits its position as fast as possible, such as a sudden change in market conditions leading to losses, or an imminent failure in an external dependency. This may only be called by governance, the guardian, or the Strategy itself. Note that a Strategy will only revoke itself during emergency shutdown.    
 
 
 
@@ -993,7 +993,7 @@ function addStrategyToQueue(address)
 ```
 
 
-@notice Adds `strategy` to `withdrawalQueue`. This may only be called by governance or management.    
+Adds `strategy` to `withdrawalQueue`. This may only be called by governance or management.    
 
 
 *The Strategy will be appended to `withdrawalQueue`, call `setWithdrawalQueue` to change the order.*
@@ -1016,7 +1016,7 @@ function removeStrategyFromQueue(address)
 ```
 
 
-@notice Remove `strategy` from `withdrawalQueue`. This may only be called by governance or management.    
+Remove `strategy` from `withdrawalQueue`. This may only be called by governance or management.    
 
 
 *We don&#39;t do this with revokeStrategy because it should still be possible to withdraw from the Strategy if it&#39;s unwinding.*
@@ -1039,7 +1039,7 @@ function debtOutstanding()
 ```
 
 
-@notice Determines if `strategy` is past its debt limit and if any tokens should be withdrawn to the Vault.    
+Determines if `strategy` is past its debt limit and if any tokens should be withdrawn to the Vault.    
 
 
 
@@ -1091,7 +1091,7 @@ function creditAvailable()
 ```
 
 
-@notice Amount of tokens in Vault a Strategy has access to as a credit line. This will check the Strategy&#39;s debt limit, as well as the tokens available in the Vault, and determine the maximum amount of tokens (if any) the Strategy may draw on. In the rare case the Vault is in emergency shutdown this will return 0.    
+Amount of tokens in Vault a Strategy has access to as a credit line. This will check the Strategy&#39;s debt limit, as well as the tokens available in the Vault, and determine the maximum amount of tokens (if any) the Strategy may draw on. In the rare case the Vault is in emergency shutdown this will return 0.    
 
 
 
@@ -1143,7 +1143,7 @@ function expectedReturn()
 ```
 
 
-@notice Provide an accurate expected value for the return this `strategy` would provide to the Vault the next time `report()` is called (since the last time it was called).    
+Provide an accurate expected value for the return this `strategy` would provide to the Vault the next time `report()` is called (since the last time it was called).    
 
 
 
@@ -1195,7 +1195,7 @@ function report(uint256,uint256,uint256)
 ```
 
 
-@notice Reports the amount of assets the calling Strategy has free (usually in terms of ROI). The performance fee is determined here, off of the strategy&#39;s profits (if any), and sent to governance. The strategist&#39;s fee is also determined here (off of profits), to be handled according to the strategist on the next harvest. This may only be called by a Strategy managed by this Vault.    
+Reports the amount of assets the calling Strategy has free (usually in terms of ROI). The performance fee is determined here, off of the strategy&#39;s profits (if any), and sent to governance. The strategist&#39;s fee is also determined here (off of profits), to be handled according to the strategist on the next harvest. This may only be called by a Strategy managed by this Vault.    
 
 
 *For approved strategies, this is the most efficient behavior. The Strategy reports back what it has free, then Vault &#34;decides&#34; whether to take some back or give it more. Note that the most it can take is `gain + _debtPayment`, and the most it can give is all of the remaining reserves. Anything outside of those bounds is abnormal behavior. All approved strategies must have increased diligence around calling this function, as abnormal behavior could become catastrophic.*
@@ -1226,7 +1226,7 @@ function sweep(address)
 ```
 
 
-@notice Removes tokens from this Vault that are not the type of token managed by this Vault. This may be used in case of accidentally sending the wrong kind of token to this Vault. Tokens will be sent to `governance`. This will fail if an attempt is made to sweep the tokens that this Vault manages. This may only be called by governance.    
+Removes tokens from this Vault that are not the type of token managed by this Vault. This may be used in case of accidentally sending the wrong kind of token to this Vault. Tokens will be sent to `governance`. This will fail if an attempt is made to sweep the tokens that this Vault manages. This may only be called by governance.    
 
 
 

--- a/versioned_docs/version-0.3.4/smart-contracts/BaseStrategy.md
+++ b/versioned_docs/version-0.3.4/smart-contracts/BaseStrategy.md
@@ -8,7 +8,7 @@
   function apiVersion(
   ) public returns (string)
 ```
-@notice
+
  Used to track which version of `StrategyAPI` this Strategy
  implements.
 
@@ -41,7 +41,7 @@ This Strategy's name.
   function delegatedAssets(
   ) external returns (uint256)
 ```
-@notice
+
  The amount (priced in want) of the total assets managed by this strategy should not count
  towards Yearn's TVL calculations.
 @dev
@@ -72,7 +72,7 @@ This Strategy's name.
     address _vault
   ) internal
 ```
-@notice
+
  Initializes the Strategy, this is called only once, when the
  contract is deployed.
 
@@ -89,7 +89,7 @@ This Strategy's name.
     address _strategist
   ) external
 ```
-@notice
+
  Used to change `strategist`.
 
  This may only be called by governance or the existing strategist.
@@ -106,7 +106,7 @@ This Strategy's name.
     address _keeper
   ) external
 ```
-@notice
+
  Used to change `keeper`.
 
  `keeper` is the only address that may call `tend()` or `harvest()`,
@@ -129,7 +129,7 @@ This Strategy's name.
     address _rewards
   ) external
 ```
-@notice
+
  Used to change `rewards`. EOA or smart contract which has the permission
  to pull rewards from the vault.
 
@@ -147,7 +147,7 @@ This Strategy's name.
     uint256 _delay
   ) external
 ```
-@notice
+
  Used to change `minReportDelay`. `minReportDelay` is the minimum number
  of blocks that should pass for `harvest()` to be called.
 
@@ -169,7 +169,7 @@ This Strategy's name.
     uint256 _delay
   ) external
 ```
-@notice
+
  Used to change `maxReportDelay`. `maxReportDelay` is the maximum number
  of blocks that should pass for `harvest()` to be called.
 
@@ -191,7 +191,7 @@ This Strategy's name.
     uint256 _profitFactor
   ) external
 ```
-@notice
+
  Used to change `profitFactor`. `profitFactor` is used to determine
  if it's worthwhile to harvest, given gas costs. (See `harvestTrigger()`
  for more details.)
@@ -211,7 +211,7 @@ This Strategy's name.
     uint256 _debtThreshold
   ) external
 ```
-@notice
+
  Sets how far the Strategy can go into loss without a harvest and report
  being required.
 
@@ -234,7 +234,7 @@ being required to report to the Vault.
     string _metadataURI
   ) external
 ```
-@notice
+
  Used to change `metadataURI`. `metadataURI` is used to store the URI
 of the file describing the strategy.
 
@@ -261,7 +261,7 @@ on protected functions in the Strategy.
   function estimatedTotalAssets(
   ) public returns (uint256)
 ```
-@notice
+
  Provide an accurate estimate for the total amount of assets
  (principle + return) that this Strategy is currently managing,
  denominated in terms of `want` tokens.
@@ -367,7 +367,7 @@ NOTE: The invariant `_liquidatedAmount + _loss <= _amountNeeded` should always b
     uint256 callCost
   ) public returns (bool)
 ```
-@notice
+
  Provide a signal to the keeper that `tend()` should be called. The
  keeper will provide the estimated gas cost that they would pay to call
  `tend()`, and this function should use that estimate to make a
@@ -397,7 +397,7 @@ NOTE: The invariant `_liquidatedAmount + _loss <= _amountNeeded` should always b
   function tend(
   ) external
 ```
-@notice
+
  Adjust the Strategy's position. The purpose of tending isn't to
  realize gains, but to maximize yield by reinvesting any returns.
 
@@ -413,7 +413,7 @@ NOTE: The invariant `_liquidatedAmount + _loss <= _amountNeeded` should always b
     uint256 callCost
   ) public returns (bool)
 ```
-@notice
+
  Provide a signal to the keeper that `harvest()` should be called. The
  keeper will provide the estimated gas cost that they would pay to call
  `harvest()`, and this function should use that estimate to make a
@@ -455,7 +455,7 @@ NOTE: The invariant `_liquidatedAmount + _loss <= _amountNeeded` should always b
   function harvest(
   ) external
 ```
-@notice
+
  Harvests the Strategy, recognizing any profits or losses and adjusting
  the Strategy's position.
 
@@ -479,7 +479,7 @@ NOTE: The invariant `_liquidatedAmount + _loss <= _amountNeeded` should always b
     uint256 _amountNeeded
   ) external returns (uint256 _loss)
 ```
-@notice
+
  Withdraws `_amountNeeded` to `vault`.
 
  This may only be called by the Vault.
@@ -511,7 +511,7 @@ value.
     address _newStrategy
   ) external
 ```
-@notice
+
  Transfers all `want` from this Strategy to `_newStrategy`.
 
  This may only be called by governance or the Vault.
@@ -529,7 +529,7 @@ value.
   function setEmergencyExit(
   ) external
 ```
-@notice
+
  Activates emergency exit. Once activated, the Strategy will exit its
  position upon the next harvest, depositing all funds into the Vault as
  quickly as is reasonable given on-chain conditions.
@@ -569,7 +569,7 @@ Example:
     address _token
   ) external
 ```
-@notice
+
  Removes tokens from this Strategy that are not the type of tokens
  managed by this Strategy. This may be used in case of accidentally
  sending the wrong kind of token to this Strategy.

--- a/versioned_docs/version-0.3.4/smart-contracts/registry.md
+++ b/versioned_docs/version-0.3.4/smart-contracts/registry.md
@@ -16,7 +16,7 @@ function setGovernance(address)
 ```
 
 
-@notice Starts the 1st phase of the governance transfer.    
+Starts the 1st phase of the governance transfer.    
 
 
 *Throws if the caller is not current governance.*
@@ -39,7 +39,7 @@ function acceptGovernance()
 ```
 
 
-@notice Completes the 2nd phase of the governance transfer.    
+Completes the 2nd phase of the governance transfer.    
 
 
 *Throws if the caller is not the pending caller. Emits a `NewGovernance` event.*
@@ -56,7 +56,7 @@ function latestRelease()
 ```
 
 
-@notice Returns the api version of the latest release.    
+Returns the api version of the latest release.    
 
 
 *Throws if no releases are registered yet.*
@@ -79,7 +79,7 @@ function latestVault(address)
 ```
 
 
-@notice Returns the latest deployed vault for the given token.    
+Returns the latest deployed vault for the given token.    
 
 
 *Throws if no vaults are endorsed yet for the given token.*
@@ -108,7 +108,7 @@ function newRelease(address)
 ```
 
 
-@notice Add a previously deployed Vault as the template contract for the latest release, to be used by further &#34;forwarder-style&#34; delegatecall proxy contracts that can be deployed from the registry throw other methods (to save gas).    
+Add a previously deployed Vault as the template contract for the latest release, to be used by further &#34;forwarder-style&#34; delegatecall proxy contracts that can be deployed from the registry throw other methods (to save gas).    
 
 
 *Throws if caller isn&#39;t `self.governance`. Throws if `vault`&#39;s governance isn&#39;t `self.governance`. Throws if the api version is the same as the previous release. Emits a `NewVault` event.*
@@ -131,7 +131,7 @@ function newVault(address,address,address,string,string)
 ```
 
 
-@notice Create a new vault for the given token using the latest release in the registry, as a simple &#34;forwarder-style&#34; delegatecall proxy to the latest release. Also adds the new vault to the list of &#34;endorsed&#34; vaults for that token.    
+Create a new vault for the given token using the latest release in the registry, as a simple &#34;forwarder-style&#34; delegatecall proxy to the latest release. Also adds the new vault to the list of &#34;endorsed&#34; vaults for that token.    
 
 
 *`governance` is set in the new vault as `self.governance`, with no ability to override. Throws if caller isn&#39;t `self.governance`. Throws if no releases are registered yet. Throws if there already is a registered vault for the given token with the latest api version. Emits a `NewVault` event.*
@@ -197,7 +197,7 @@ function newExperimentalVault(address,address,address,address,string,string)
 ```
 
 
-@notice Create a new vault for the given token using the latest release in the registry, as a simple &#34;forwarder-style&#34; delegatecall proxy to the latest release. Does not add the new vault to the list of &#34;endorsed&#34; vaults for that token.    
+Create a new vault for the given token using the latest release in the registry, as a simple &#34;forwarder-style&#34; delegatecall proxy to the latest release. Does not add the new vault to the list of &#34;endorsed&#34; vaults for that token.    
 
 
 *Throws if no releases are registered yet. Emits a `NewExperimentalVault` event.*
@@ -265,7 +265,7 @@ function endorseVault(address)
 ```
 
 
-@notice Adds an existing vault to the list of &#34;endorsed&#34; vaults for that token.    
+Adds an existing vault to the list of &#34;endorsed&#34; vaults for that token.    
 
 
 *`governance` is set in the new vault as `self.governance`, with no ability to override. Throws if caller isn&#39;t `self.governance`. Throws if `vault`&#39;s governance isn&#39;t `self.governance`. Throws if no releases are registered yet. Throws if `vault`&#39;s api version does not match latest release. Throws if there already is a deployment for the vault&#39;s token with the latest api version. Emits a `NewVault` event.*
@@ -311,7 +311,7 @@ function setBanksy(address)
 ```
 
 
-@notice Set the ability of a particular tagger to tag current vaults.    
+Set the ability of a particular tagger to tag current vaults.    
 
 
 *Throws if caller is not `self.governance`.*
@@ -357,7 +357,7 @@ function tagVault(address,string)
 ```
 
 
-@notice Tag a Vault with a message.    
+Tag a Vault with a message.    
 
 
 *Throws if caller is not `self.governance` or an approved tagger. Emits a `VaultTagged` event.*

--- a/versioned_docs/version-0.3.4/smart-contracts/vault.md
+++ b/versioned_docs/version-0.3.4/smart-contracts/vault.md
@@ -20,7 +20,7 @@ function initialize(address,address,address,string,string)
 ```
 
 
-@notice Initializes the Vault, this is called only once, when the contract is deployed. The performance fee is set to 10% of yield, per Strategy. The management fee is set to 2%, per year. The initial deposit limit is set to 0 (deposits disabled); it must be updated after initialization.    
+Initializes the Vault, this is called only once, when the contract is deployed. The performance fee is set to 10% of yield, per Strategy. The management fee is set to 2%, per year. The initial deposit limit is set to 0 (deposits disabled); it must be updated after initialization.    
 
 
 *If `nameOverride` is not specified, the name will be &#39;yearn&#39; combined with the name of `token`. If `symbolOverride` is not specified, the symbol will be &#39;y&#39; combined with the symbol of `token`.*
@@ -74,7 +74,7 @@ function apiVersion()
 ```
 
 
-@notice Used to track the deployed version of this contract. In practice you can use this version number to compare with Yearn&#39;s GitHub and determine which version of the source matches this deployed contract.    
+Used to track the deployed version of this contract. In practice you can use this version number to compare with Yearn&#39;s GitHub and determine which version of the source matches this deployed contract.    
 
 
 *All strategies must have an `apiVersion()` that matches the Vault&#39;s `API_VERSION`.*
@@ -97,7 +97,7 @@ function setName(string)
 ```
 
 
-@notice Used to change the value of `name`. This may only be called by governance.    
+Used to change the value of `name`. This may only be called by governance.    
 
 
 
@@ -118,7 +118,7 @@ function setSymbol(string)
 ```
 
 
-@notice Used to change the value of `symbol`. This may only be called by governance.    
+Used to change the value of `symbol`. This may only be called by governance.    
 
 
 
@@ -139,7 +139,7 @@ function setGovernance(address)
 ```
 
 
-@notice Nominate a new address to use as governance. The change does not go into effect immediately. This function sets a pending change, and the governance address is not updated until the proposed governance address has accepted the responsibility. This may only be called by the current governance address.    
+Nominate a new address to use as governance. The change does not go into effect immediately. This function sets a pending change, and the governance address is not updated until the proposed governance address has accepted the responsibility. This may only be called by the current governance address.    
 
 
 
@@ -160,7 +160,7 @@ function acceptGovernance()
 ```
 
 
-@notice Once a new governance address has been proposed using setGovernance(), this function may be called by the proposed address to accept the responsibility of taking over governance for this contract. This may only be called by the proposed governance address.    
+Once a new governance address has been proposed using setGovernance(), this function may be called by the proposed address to accept the responsibility of taking over governance for this contract. This may only be called by the proposed governance address.    
 
 
 *setGovernance() should be called by the existing governance address, prior to calling this function.*
@@ -177,7 +177,7 @@ function setManagement(address)
 ```
 
 
-@notice Changes the management address. Management is able to make some investment decisions adjusting parameters. This may only be called by governance.    
+Changes the management address. Management is able to make some investment decisions adjusting parameters. This may only be called by governance.    
 
 
 
@@ -198,7 +198,7 @@ function setGuestList(address)
 ```
 
 
-@notice Used to set or change `guestList`. A guest list is another contract that dictates who is allowed to participate in a Vault (and transfer shares). This may only be called by governance.    
+Used to set or change `guestList`. A guest list is another contract that dictates who is allowed to participate in a Vault (and transfer shares). This may only be called by governance.    
 
 
 
@@ -219,7 +219,7 @@ function setRewards(address)
 ```
 
 
-@notice Changes the rewards address. Any distributed rewards will cease flowing to the old address and begin flowing to this address once the change is in effect. This will not change any Strategy reports in progress, only new reports made after this change goes into effect. This may only be called by governance.    
+Changes the rewards address. Any distributed rewards will cease flowing to the old address and begin flowing to this address once the change is in effect. This will not change any Strategy reports in progress, only new reports made after this change goes into effect. This may only be called by governance.    
 
 
 
@@ -240,7 +240,7 @@ function setLockedProfitDegration(uint256)
 ```
 
 
-@notice Changes the locked profit degration.    
+Changes the locked profit degration.    
 
 
 
@@ -261,7 +261,7 @@ function setDepositLimit(uint256)
 ```
 
 
-@notice Changes the maximum amount of tokens that can be deposited in this Vault. Note, this is not how much may be deposited by a single depositor, but the maximum amount that may be deposited across all depositors. This may only be called by governance.    
+Changes the maximum amount of tokens that can be deposited in this Vault. Note, this is not how much may be deposited by a single depositor, but the maximum amount that may be deposited across all depositors. This may only be called by governance.    
 
 
 
@@ -282,7 +282,7 @@ function setPerformanceFee(uint256)
 ```
 
 
-@notice Used to change the value of `performanceFee`. Should set this value below the maximum strategist performance fee. This may only be called by governance.    
+Used to change the value of `performanceFee`. Should set this value below the maximum strategist performance fee. This may only be called by governance.    
 
 
 
@@ -303,7 +303,7 @@ function setManagementFee(uint256)
 ```
 
 
-@notice Used to change the value of `managementFee`. This may only be called by governance.    
+Used to change the value of `managementFee`. This may only be called by governance.    
 
 
 
@@ -324,7 +324,7 @@ function setGuardian(address)
 ```
 
 
-@notice Used to change the address of `guardian`. This may only be called by governance or the existing guardian.    
+Used to change the address of `guardian`. This may only be called by governance or the existing guardian.    
 
 
 
@@ -345,7 +345,7 @@ function setEmergencyShutdown(bool)
 ```
 
 
-@notice Activates or deactivates Vault mode where all Strategies go into full withdrawal. During Emergency Shutdown: 1. No Users may deposit into the Vault (but may withdraw as usual.) 2. Governance may not add new Strategies. 3. Each Strategy must pay back their debt as quickly as reasonable to minimally affect their position. 4. Only Governance may undo Emergency Shutdown. See contract level note for further details. This may only be called by governance or the guardian.    
+Activates or deactivates Vault mode where all Strategies go into full withdrawal. During Emergency Shutdown: 1. No Users may deposit into the Vault (but may withdraw as usual.) 2. Governance may not add new Strategies. 3. Each Strategy must pay back their debt as quickly as reasonable to minimally affect their position. 4. Only Governance may undo Emergency Shutdown. See contract level note for further details. This may only be called by governance or the guardian.    
 
 
 
@@ -366,7 +366,7 @@ function setWithdrawalQueue(address[20])
 ```
 
 
-@notice Updates the withdrawalQueue to match the addresses and order specified by `queue`. There can be fewer strategies than the maximum, as well as fewer than the total number of strategies active in the vault. `withdrawalQueue` will be updated in a gas-efficient manner, assuming the input is well- ordered with 0x0 only at the end. This may only be called by governance or management.    
+Updates the withdrawalQueue to match the addresses and order specified by `queue`. There can be fewer strategies than the maximum, as well as fewer than the total number of strategies active in the vault. `withdrawalQueue` will be updated in a gas-efficient manner, assuming the input is well- ordered with 0x0 only at the end. This may only be called by governance or management.    
 
 
 *This is order sensitive, specify the addresses in the order in which funds should be withdrawn (so `queue`[0] is the first Strategy withdrawn from, `queue`[1] is the second, etc.) This means that the least impactful Strategy (the Strategy that will have its core positions impacted the least by having funds removed) should be at `queue`[0], then the next least impactful at `queue`[1], and so on.*
@@ -389,7 +389,7 @@ function transfer(address,uint256)
 ```
 
 
-@notice Transfers shares from the caller&#39;s address to `receiver`. This function will always return true, unless the user is attempting to transfer shares to this contract&#39;s address, or to 0x0.    
+Transfers shares from the caller&#39;s address to `receiver`. This function will always return true, unless the user is attempting to transfer shares to this contract&#39;s address, or to 0x0.    
 
 
 
@@ -417,7 +417,7 @@ function transferFrom(address,address,uint256)
 ```
 
 
-@notice Transfers `amount` shares from `sender` to `receiver`. This operation will always return true, unless the user is attempting to transfer shares to this contract&#39;s address, or to 0x0. Unless the caller has given this contract unlimited approval, transfering shares will decrement the caller&#39;s `allowance` by `amount`.    
+Transfers `amount` shares from `sender` to `receiver`. This operation will always return true, unless the user is attempting to transfer shares to this contract&#39;s address, or to 0x0. Unless the caller has given this contract unlimited approval, transfering shares will decrement the caller&#39;s `allowance` by `amount`.    
 
 
 
@@ -512,7 +512,7 @@ function permit(address,address,uint256,uint256,bytes)
 ```
 
 
-@notice Approves spender by owner&#39;s signature to expend owner&#39;s tokens. See https://eips.ethereum.org/EIPS/eip-2612.    
+Approves spender by owner&#39;s signature to expend owner&#39;s tokens. See https://eips.ethereum.org/EIPS/eip-2612.    
 
 
 
@@ -543,7 +543,7 @@ function totalAssets()
 ```
 
 
-@notice Returns the total quantity of all assets under control of this Vault, whether they&#39;re loaned out to a Strategy, or currently held in the Vault.    
+Returns the total quantity of all assets under control of this Vault, whether they&#39;re loaned out to a Strategy, or currently held in the Vault.    
 
 
 
@@ -564,7 +564,7 @@ function deposit()
 ```
 
 
-@notice Deposits `_amount` `token`, issuing shares to `recipient`. If the Vault is in Emergency Shutdown, deposits will not be accepted and this call will fail.    
+Deposits `_amount` `token`, issuing shares to `recipient`. If the Vault is in Emergency Shutdown, deposits will not be accepted and this call will fail.    
 
 
 *Measuring quantity of shares to issues is based on the total outstanding debt that this contract has (&#34;expected value&#34;) instead of the total balance sheet it has (&#34;estimated value&#34;) has important security considerations, and is done intentionally. If this value were measured against external systems, it could be purposely manipulated by an attacker to withdraw more assets than they otherwise should be able to claim by redeeming their shares. On deposit, this means that shares are issued against the total amount that the deposited capital can be given in service of the debt that Strategies assume. If that number were to be lower than the &#34;expected value&#34; at some future point, depositing shares via this method could entitle the depositor to *less* than the deposited value once the &#34;realized value&#34; is updated from further reports by the Strategies to the Vaults. Care should be taken by integrators to account for this discrepancy, by using the view-only methods of this contract (both off-chain and on-chain) to determine if depositing into the Vault is a &#34;good idea&#34;.*
@@ -650,7 +650,7 @@ function maxAvailableShares()
 ```
 
 
-@notice Determines the maximum quantity of shares this Vault can facilitate a withdrawal for, factoring in assets currently residing in the Vault, as well as those deployed to strategies on the Vault&#39;s balance sheet.    
+Determines the maximum quantity of shares this Vault can facilitate a withdrawal for, factoring in assets currently residing in the Vault, as well as those deployed to strategies on the Vault&#39;s balance sheet.    
 
 
 *Regarding how shares are calculated, see dev note on `deposit`. If you want to calculated the maximum a user could withdraw up to, you want to use this function. Note that the amount provided by this function is the theoretical maximum possible from withdrawing, the real amount depends on the realized losses incurred during withdrawal.*
@@ -673,7 +673,7 @@ function withdraw()
 ```
 
 
-@notice Withdraws the calling account&#39;s tokens from this Vault, redeeming amount `_shares` for an appropriate amount of tokens. See note on `setWithdrawalQueue` for further details of withdrawal ordering and behavior.    
+Withdraws the calling account&#39;s tokens from this Vault, redeeming amount `_shares` for an appropriate amount of tokens. See note on `setWithdrawalQueue` for further details of withdrawal ordering and behavior.    
 
 
 *Measuring the value of shares is based on the total outstanding debt that this contract has (&#34;expected value&#34;) instead of the total balance sheet it has (&#34;estimated value&#34;) has important security considerations, and is done intentionally. If this value were measured against external systems, it could be purposely manipulated by an attacker to withdraw more assets than they otherwise should be able to claim by redeeming their shares. On withdrawal, this means that shares are redeemed against the total amount that the deposited capital had &#34;realized&#34; since the point it was deposited, up until the point it was withdrawn. If that number were to be higher than the &#34;expected value&#34; at some future point, withdrawing shares via this method could entitle the depositor to *more* than the expected value once the &#34;realized value&#34; is updated from further reports by the Strategies to the Vaults. Under exceptional scenarios, this could cause earlier withdrawals to earn &#34;more&#34; of the underlying assets than Users might otherwise be entitled to, if the Vault&#39;s estimated value were otherwise measured through external means, accounting for whatever exceptional scenarios exist for the Vault (that aren&#39;t covered by the Vault&#39;s own design.)*
@@ -791,7 +791,7 @@ function pricePerShare()
 ```
 
 
-@notice Gives the price for a single Vault share.    
+Gives the price for a single Vault share.    
 
 
 *See dev note on `withdraw`.*
@@ -814,7 +814,7 @@ function addStrategy(address,uint256,uint256,uint256,uint256)
 ```
 
 
-@notice Add a Strategy to the Vault. This may only be called by governance.    
+Add a Strategy to the Vault. This may only be called by governance.    
 
 
 *The Strategy will be appended to `withdrawalQueue`, call `setWithdrawalQueue` to change the order.*
@@ -841,7 +841,7 @@ function updateStrategyDebtRatio(address,uint256)
 ```
 
 
-@notice Change the quantity of assets `strategy` may manage. This may be called by governance or management.    
+Change the quantity of assets `strategy` may manage. This may be called by governance or management.    
 
 
 
@@ -863,7 +863,7 @@ function updateStrategyMinDebtPerHarvest(address,uint256)
 ```
 
 
-@notice Change the quantity assets per block this Vault may deposit to or withdraw from `strategy`. This may only be called by governance or management.    
+Change the quantity assets per block this Vault may deposit to or withdraw from `strategy`. This may only be called by governance or management.    
 
 
 
@@ -885,7 +885,7 @@ function updateStrategyMaxDebtPerHarvest(address,uint256)
 ```
 
 
-@notice Change the quantity assets per block this Vault may deposit to or withdraw from `strategy`. This may only be called by governance or management.    
+Change the quantity assets per block this Vault may deposit to or withdraw from `strategy`. This may only be called by governance or management.    
 
 
 
@@ -907,7 +907,7 @@ function updateStrategyPerformanceFee(address,uint256)
 ```
 
 
-@notice Change the fee the strategist will receive based on this Vault&#39;s performance. This may only be called by governance.    
+Change the fee the strategist will receive based on this Vault&#39;s performance. This may only be called by governance.    
 
 
 
@@ -929,7 +929,7 @@ function migrateStrategy(address,address)
 ```
 
 
-@notice Migrates a Strategy, including all assets from `oldVersion` to `newVersion`. This may only be called by governance.    
+Migrates a Strategy, including all assets from `oldVersion` to `newVersion`. This may only be called by governance.    
 
 
 *Strategy must successfully migrate all capital and positions to new Strategy, or else this will upset the balance of the Vault. The new Strategy should be &#34;empty&#34; e.g. have no prior commitments to this Vault, otherwise it could have issues.*
@@ -953,7 +953,7 @@ function revokeStrategy()
 ```
 
 
-@notice Revoke a Strategy, setting its debt limit to 0 and preventing any future deposits. This function should only be used in the scenario where the Strategy is being retired but no migration of the positions are possible, or in the extreme scenario that the Strategy needs to be put into &#34;Emergency Exit&#34; mode in order for it to exit as quickly as possible. The latter scenario could be for any reason that is considered &#34;critical&#34; that the Strategy exits its position as fast as possible, such as a sudden change in market conditions leading to losses, or an imminent failure in an external dependency. This may only be called by governance, the guardian, or the Strategy itself. Note that a Strategy will only revoke itself during emergency shutdown.    
+Revoke a Strategy, setting its debt limit to 0 and preventing any future deposits. This function should only be used in the scenario where the Strategy is being retired but no migration of the positions are possible, or in the extreme scenario that the Strategy needs to be put into &#34;Emergency Exit&#34; mode in order for it to exit as quickly as possible. The latter scenario could be for any reason that is considered &#34;critical&#34; that the Strategy exits its position as fast as possible, such as a sudden change in market conditions leading to losses, or an imminent failure in an external dependency. This may only be called by governance, the guardian, or the Strategy itself. Note that a Strategy will only revoke itself during emergency shutdown.    
 
 
 
@@ -993,7 +993,7 @@ function addStrategyToQueue(address)
 ```
 
 
-@notice Adds `strategy` to `withdrawalQueue`. This may only be called by governance or management.    
+Adds `strategy` to `withdrawalQueue`. This may only be called by governance or management.    
 
 
 *The Strategy will be appended to `withdrawalQueue`, call `setWithdrawalQueue` to change the order.*
@@ -1016,7 +1016,7 @@ function removeStrategyFromQueue(address)
 ```
 
 
-@notice Remove `strategy` from `withdrawalQueue`. This may only be called by governance or management.    
+Remove `strategy` from `withdrawalQueue`. This may only be called by governance or management.    
 
 
 *We don&#39;t do this with revokeStrategy because it should still be possible to withdraw from the Strategy if it&#39;s unwinding.*
@@ -1039,7 +1039,7 @@ function debtOutstanding()
 ```
 
 
-@notice Determines if `strategy` is past its debt limit and if any tokens should be withdrawn to the Vault.    
+Determines if `strategy` is past its debt limit and if any tokens should be withdrawn to the Vault.    
 
 
 
@@ -1091,7 +1091,7 @@ function creditAvailable()
 ```
 
 
-@notice Amount of tokens in Vault a Strategy has access to as a credit line. This will check the Strategy&#39;s debt limit, as well as the tokens available in the Vault, and determine the maximum amount of tokens (if any) the Strategy may draw on. In the rare case the Vault is in emergency shutdown this will return 0.    
+Amount of tokens in Vault a Strategy has access to as a credit line. This will check the Strategy&#39;s debt limit, as well as the tokens available in the Vault, and determine the maximum amount of tokens (if any) the Strategy may draw on. In the rare case the Vault is in emergency shutdown this will return 0.    
 
 
 
@@ -1143,7 +1143,7 @@ function expectedReturn()
 ```
 
 
-@notice Provide an accurate expected value for the return this `strategy` would provide to the Vault the next time `report()` is called (since the last time it was called).    
+Provide an accurate expected value for the return this `strategy` would provide to the Vault the next time `report()` is called (since the last time it was called).    
 
 
 
@@ -1195,7 +1195,7 @@ function report(uint256,uint256,uint256)
 ```
 
 
-@notice Reports the amount of assets the calling Strategy has free (usually in terms of ROI). The performance fee is determined here, off of the strategy&#39;s profits (if any), and sent to governance. The strategist&#39;s fee is also determined here (off of profits), to be handled according to the strategist on the next harvest. This may only be called by a Strategy managed by this Vault.    
+Reports the amount of assets the calling Strategy has free (usually in terms of ROI). The performance fee is determined here, off of the strategy&#39;s profits (if any), and sent to governance. The strategist&#39;s fee is also determined here (off of profits), to be handled according to the strategist on the next harvest. This may only be called by a Strategy managed by this Vault.    
 
 
 *For approved strategies, this is the most efficient behavior. The Strategy reports back what it has free, then Vault &#34;decides&#34; whether to take some back or give it more. Note that the most it can take is `gain + _debtPayment`, and the most it can give is all of the remaining reserves. Anything outside of those bounds is abnormal behavior. All approved strategies must have increased diligence around calling this function, as abnormal behavior could become catastrophic.*
@@ -1226,7 +1226,7 @@ function sweep(address)
 ```
 
 
-@notice Removes tokens from this Vault that are not the type of token managed by this Vault. This may be used in case of accidentally sending the wrong kind of token to this Vault. Tokens will be sent to `governance`. This will fail if an attempt is made to sweep the tokens that this Vault manages. This may only be called by governance.    
+Removes tokens from this Vault that are not the type of token managed by this Vault. This may be used in case of accidentally sending the wrong kind of token to this Vault. Tokens will be sent to `governance`. This will fail if an attempt is made to sweep the tokens that this Vault manages. This may only be called by governance.    
 
 
 

--- a/versioned_docs/version-0.3.5/smart-contracts/BaseStrategy.md
+++ b/versioned_docs/version-0.3.5/smart-contracts/BaseStrategy.md
@@ -8,7 +8,7 @@
   function apiVersion(
   ) public returns (string)
 ```
-@notice
+
  Used to track which version of `StrategyAPI` this Strategy
  implements.
 
@@ -41,7 +41,7 @@ This Strategy's name.
   function delegatedAssets(
   ) external returns (uint256)
 ```
-@notice
+
  The amount (priced in want) of the total assets managed by this strategy should not count
  towards Yearn's TVL calculations.
 @dev
@@ -72,7 +72,7 @@ This Strategy's name.
     address _vault
   ) internal
 ```
-@notice
+
  Initializes the Strategy, this is called only once, when the
  contract is deployed.
 
@@ -89,7 +89,7 @@ This Strategy's name.
     address _strategist
   ) external
 ```
-@notice
+
  Used to change `strategist`.
 
  This may only be called by governance or the existing strategist.
@@ -106,7 +106,7 @@ This Strategy's name.
     address _keeper
   ) external
 ```
-@notice
+
  Used to change `keeper`.
 
  `keeper` is the only address that may call `tend()` or `harvest()`,
@@ -129,7 +129,7 @@ This Strategy's name.
     address _rewards
   ) external
 ```
-@notice
+
  Used to change `rewards`. EOA or smart contract which has the permission
  to pull rewards from the vault.
 
@@ -147,7 +147,7 @@ This Strategy's name.
     uint256 _delay
   ) external
 ```
-@notice
+
  Used to change `minReportDelay`. `minReportDelay` is the minimum number
  of blocks that should pass for `harvest()` to be called.
 
@@ -169,7 +169,7 @@ This Strategy's name.
     uint256 _delay
   ) external
 ```
-@notice
+
  Used to change `maxReportDelay`. `maxReportDelay` is the maximum number
  of blocks that should pass for `harvest()` to be called.
 
@@ -191,7 +191,7 @@ This Strategy's name.
     uint256 _profitFactor
   ) external
 ```
-@notice
+
  Used to change `profitFactor`. `profitFactor` is used to determine
  if it's worthwhile to harvest, given gas costs. (See `harvestTrigger()`
  for more details.)
@@ -211,7 +211,7 @@ This Strategy's name.
     uint256 _debtThreshold
   ) external
 ```
-@notice
+
  Sets how far the Strategy can go into loss without a harvest and report
  being required.
 
@@ -234,7 +234,7 @@ being required to report to the Vault.
     string _metadataURI
   ) external
 ```
-@notice
+
  Used to change `metadataURI`. `metadataURI` is used to store the URI
 of the file describing the strategy.
 
@@ -261,7 +261,7 @@ on protected functions in the Strategy.
   function estimatedTotalAssets(
   ) public returns (uint256)
 ```
-@notice
+
  Provide an accurate estimate for the total amount of assets
  (principle + return) that this Strategy is currently managing,
  denominated in terms of `want` tokens.
@@ -367,7 +367,7 @@ NOTE: The invariant `_liquidatedAmount + _loss <= _amountNeeded` should always b
     uint256 callCost
   ) public returns (bool)
 ```
-@notice
+
  Provide a signal to the keeper that `tend()` should be called. The
  keeper will provide the estimated gas cost that they would pay to call
  `tend()`, and this function should use that estimate to make a
@@ -397,7 +397,7 @@ NOTE: The invariant `_liquidatedAmount + _loss <= _amountNeeded` should always b
   function tend(
   ) external
 ```
-@notice
+
  Adjust the Strategy's position. The purpose of tending isn't to
  realize gains, but to maximize yield by reinvesting any returns.
 
@@ -413,7 +413,7 @@ NOTE: The invariant `_liquidatedAmount + _loss <= _amountNeeded` should always b
     uint256 callCost
   ) public returns (bool)
 ```
-@notice
+
  Provide a signal to the keeper that `harvest()` should be called. The
  keeper will provide the estimated gas cost that they would pay to call
  `harvest()`, and this function should use that estimate to make a
@@ -455,7 +455,7 @@ NOTE: The invariant `_liquidatedAmount + _loss <= _amountNeeded` should always b
   function harvest(
   ) external
 ```
-@notice
+
  Harvests the Strategy, recognizing any profits or losses and adjusting
  the Strategy's position.
 
@@ -479,7 +479,7 @@ NOTE: The invariant `_liquidatedAmount + _loss <= _amountNeeded` should always b
     uint256 _amountNeeded
   ) external returns (uint256 _loss)
 ```
-@notice
+
  Withdraws `_amountNeeded` to `vault`.
 
  This may only be called by the Vault.
@@ -511,7 +511,7 @@ value.
     address _newStrategy
   ) external
 ```
-@notice
+
  Transfers all `want` from this Strategy to `_newStrategy`.
 
  This may only be called by governance or the Vault.
@@ -529,7 +529,7 @@ value.
   function setEmergencyExit(
   ) external
 ```
-@notice
+
  Activates emergency exit. Once activated, the Strategy will exit its
  position upon the next harvest, depositing all funds into the Vault as
  quickly as is reasonable given on-chain conditions.
@@ -569,7 +569,7 @@ Example:
     address _token
   ) external
 ```
-@notice
+
  Removes tokens from this Strategy that are not the type of tokens
  managed by this Strategy. This may be used in case of accidentally
  sending the wrong kind of token to this Strategy.

--- a/versioned_docs/version-0.3.5/smart-contracts/registry.md
+++ b/versioned_docs/version-0.3.5/smart-contracts/registry.md
@@ -16,7 +16,7 @@ function setGovernance(address)
 ```
 
 
-@notice Starts the 1st phase of the governance transfer.    
+Starts the 1st phase of the governance transfer.    
 
 
 *Throws if the caller is not current governance.*
@@ -39,7 +39,7 @@ function acceptGovernance()
 ```
 
 
-@notice Completes the 2nd phase of the governance transfer.    
+Completes the 2nd phase of the governance transfer.    
 
 
 *Throws if the caller is not the pending caller. Emits a `NewGovernance` event.*
@@ -56,7 +56,7 @@ function latestRelease()
 ```
 
 
-@notice Returns the api version of the latest release.    
+Returns the api version of the latest release.    
 
 
 *Throws if no releases are registered yet.*
@@ -79,7 +79,7 @@ function latestVault(address)
 ```
 
 
-@notice Returns the latest deployed vault for the given token.    
+Returns the latest deployed vault for the given token.    
 
 
 *Throws if no vaults are endorsed yet for the given token.*
@@ -108,7 +108,7 @@ function newRelease(address)
 ```
 
 
-@notice Add a previously deployed Vault as the template contract for the latest release, to be used by further &#34;forwarder-style&#34; delegatecall proxy contracts that can be deployed from the registry throw other methods (to save gas).    
+Add a previously deployed Vault as the template contract for the latest release, to be used by further &#34;forwarder-style&#34; delegatecall proxy contracts that can be deployed from the registry throw other methods (to save gas).    
 
 
 *Throws if caller isn&#39;t `self.governance`. Throws if `vault`&#39;s governance isn&#39;t `self.governance`. Throws if the api version is the same as the previous release. Emits a `NewVault` event.*
@@ -131,7 +131,7 @@ function newVault(address,address,address,string,string)
 ```
 
 
-@notice Create a new vault for the given token using the latest release in the registry, as a simple &#34;forwarder-style&#34; delegatecall proxy to the latest release. Also adds the new vault to the list of &#34;endorsed&#34; vaults for that token.    
+Create a new vault for the given token using the latest release in the registry, as a simple &#34;forwarder-style&#34; delegatecall proxy to the latest release. Also adds the new vault to the list of &#34;endorsed&#34; vaults for that token.    
 
 
 *`governance` is set in the new vault as `self.governance`, with no ability to override. Throws if caller isn&#39;t `self.governance`. Throws if no releases are registered yet. Throws if there already is a registered vault for the given token with the latest api version. Emits a `NewVault` event.*
@@ -197,7 +197,7 @@ function newExperimentalVault(address,address,address,address,string,string)
 ```
 
 
-@notice Create a new vault for the given token using the latest release in the registry, as a simple &#34;forwarder-style&#34; delegatecall proxy to the latest release. Does not add the new vault to the list of &#34;endorsed&#34; vaults for that token.    
+Create a new vault for the given token using the latest release in the registry, as a simple &#34;forwarder-style&#34; delegatecall proxy to the latest release. Does not add the new vault to the list of &#34;endorsed&#34; vaults for that token.    
 
 
 *Throws if no releases are registered yet. Emits a `NewExperimentalVault` event.*
@@ -265,7 +265,7 @@ function endorseVault(address)
 ```
 
 
-@notice Adds an existing vault to the list of &#34;endorsed&#34; vaults for that token.    
+Adds an existing vault to the list of &#34;endorsed&#34; vaults for that token.    
 
 
 *`governance` is set in the new vault as `self.governance`, with no ability to override. Throws if caller isn&#39;t `self.governance`. Throws if `vault`&#39;s governance isn&#39;t `self.governance`. Throws if no releases are registered yet. Throws if `vault`&#39;s api version does not match latest release. Throws if there already is a deployment for the vault&#39;s token with the latest api version. Emits a `NewVault` event.*
@@ -311,7 +311,7 @@ function setBanksy(address)
 ```
 
 
-@notice Set the ability of a particular tagger to tag current vaults.    
+Set the ability of a particular tagger to tag current vaults.    
 
 
 *Throws if caller is not `self.governance`.*
@@ -357,7 +357,7 @@ function tagVault(address,string)
 ```
 
 
-@notice Tag a Vault with a message.    
+Tag a Vault with a message.    
 
 
 *Throws if caller is not `self.governance` or an approved tagger. Emits a `VaultTagged` event.*

--- a/versioned_docs/version-0.3.5/smart-contracts/vault.md
+++ b/versioned_docs/version-0.3.5/smart-contracts/vault.md
@@ -20,7 +20,7 @@ function initialize(address,address,address,string,string)
 ```
 
 
-@notice Initializes the Vault, this is called only once, when the contract is deployed. The performance fee is set to 10% of yield, per Strategy. The management fee is set to 2%, per year. The initial deposit limit is set to 0 (deposits disabled); it must be updated after initialization.    
+Initializes the Vault, this is called only once, when the contract is deployed. The performance fee is set to 10% of yield, per Strategy. The management fee is set to 2%, per year. The initial deposit limit is set to 0 (deposits disabled); it must be updated after initialization.    
 
 
 *If `nameOverride` is not specified, the name will be &#39;yearn&#39; combined with the name of `token`. If `symbolOverride` is not specified, the symbol will be &#39;y&#39; combined with the symbol of `token`.*
@@ -74,7 +74,7 @@ function apiVersion()
 ```
 
 
-@notice Used to track the deployed version of this contract. In practice you can use this version number to compare with Yearn&#39;s GitHub and determine which version of the source matches this deployed contract.    
+Used to track the deployed version of this contract. In practice you can use this version number to compare with Yearn&#39;s GitHub and determine which version of the source matches this deployed contract.    
 
 
 *All strategies must have an `apiVersion()` that matches the Vault&#39;s `API_VERSION`.*
@@ -97,7 +97,7 @@ function setName(string)
 ```
 
 
-@notice Used to change the value of `name`. This may only be called by governance.    
+Used to change the value of `name`. This may only be called by governance.    
 
 
 
@@ -118,7 +118,7 @@ function setSymbol(string)
 ```
 
 
-@notice Used to change the value of `symbol`. This may only be called by governance.    
+Used to change the value of `symbol`. This may only be called by governance.    
 
 
 
@@ -139,7 +139,7 @@ function setGovernance(address)
 ```
 
 
-@notice Nominate a new address to use as governance. The change does not go into effect immediately. This function sets a pending change, and the governance address is not updated until the proposed governance address has accepted the responsibility. This may only be called by the current governance address.    
+Nominate a new address to use as governance. The change does not go into effect immediately. This function sets a pending change, and the governance address is not updated until the proposed governance address has accepted the responsibility. This may only be called by the current governance address.    
 
 
 
@@ -160,7 +160,7 @@ function acceptGovernance()
 ```
 
 
-@notice Once a new governance address has been proposed using setGovernance(), this function may be called by the proposed address to accept the responsibility of taking over governance for this contract. This may only be called by the proposed governance address.    
+Once a new governance address has been proposed using setGovernance(), this function may be called by the proposed address to accept the responsibility of taking over governance for this contract. This may only be called by the proposed governance address.    
 
 
 *setGovernance() should be called by the existing governance address, prior to calling this function.*
@@ -177,7 +177,7 @@ function setManagement(address)
 ```
 
 
-@notice Changes the management address. Management is able to make some investment decisions adjusting parameters. This may only be called by governance.    
+Changes the management address. Management is able to make some investment decisions adjusting parameters. This may only be called by governance.    
 
 
 
@@ -198,7 +198,7 @@ function setGuestList(address)
 ```
 
 
-@notice Used to set or change `guestList`. A guest list is another contract that dictates who is allowed to participate in a Vault (and transfer shares). This may only be called by governance.    
+Used to set or change `guestList`. A guest list is another contract that dictates who is allowed to participate in a Vault (and transfer shares). This may only be called by governance.    
 
 
 
@@ -219,7 +219,7 @@ function setRewards(address)
 ```
 
 
-@notice Changes the rewards address. Any distributed rewards will cease flowing to the old address and begin flowing to this address once the change is in effect. This will not change any Strategy reports in progress, only new reports made after this change goes into effect. This may only be called by governance.    
+Changes the rewards address. Any distributed rewards will cease flowing to the old address and begin flowing to this address once the change is in effect. This will not change any Strategy reports in progress, only new reports made after this change goes into effect. This may only be called by governance.    
 
 
 
@@ -240,7 +240,7 @@ function setLockedProfitDegration(uint256)
 ```
 
 
-@notice Changes the locked profit degration.    
+Changes the locked profit degration.    
 
 
 
@@ -261,7 +261,7 @@ function setDepositLimit(uint256)
 ```
 
 
-@notice Changes the maximum amount of tokens that can be deposited in this Vault. Note, this is not how much may be deposited by a single depositor, but the maximum amount that may be deposited across all depositors. This may only be called by governance.    
+Changes the maximum amount of tokens that can be deposited in this Vault. Note, this is not how much may be deposited by a single depositor, but the maximum amount that may be deposited across all depositors. This may only be called by governance.    
 
 
 
@@ -282,7 +282,7 @@ function setPerformanceFee(uint256)
 ```
 
 
-@notice Used to change the value of `performanceFee`. Should set this value below the maximum strategist performance fee. This may only be called by governance.    
+Used to change the value of `performanceFee`. Should set this value below the maximum strategist performance fee. This may only be called by governance.    
 
 
 
@@ -303,7 +303,7 @@ function setManagementFee(uint256)
 ```
 
 
-@notice Used to change the value of `managementFee`. This may only be called by governance.    
+Used to change the value of `managementFee`. This may only be called by governance.    
 
 
 
@@ -324,7 +324,7 @@ function setGuardian(address)
 ```
 
 
-@notice Used to change the address of `guardian`. This may only be called by governance or the existing guardian.    
+Used to change the address of `guardian`. This may only be called by governance or the existing guardian.    
 
 
 
@@ -345,7 +345,7 @@ function setEmergencyShutdown(bool)
 ```
 
 
-@notice Activates or deactivates Vault mode where all Strategies go into full withdrawal. During Emergency Shutdown: 1. No Users may deposit into the Vault (but may withdraw as usual.) 2. Governance may not add new Strategies. 3. Each Strategy must pay back their debt as quickly as reasonable to minimally affect their position. 4. Only Governance may undo Emergency Shutdown. See contract level note for further details. This may only be called by governance or the guardian.    
+Activates or deactivates Vault mode where all Strategies go into full withdrawal. During Emergency Shutdown: 1. No Users may deposit into the Vault (but may withdraw as usual.) 2. Governance may not add new Strategies. 3. Each Strategy must pay back their debt as quickly as reasonable to minimally affect their position. 4. Only Governance may undo Emergency Shutdown. See contract level note for further details. This may only be called by governance or the guardian.    
 
 
 
@@ -366,7 +366,7 @@ function setWithdrawalQueue(address[20])
 ```
 
 
-@notice Updates the withdrawalQueue to match the addresses and order specified by `queue`. There can be fewer strategies than the maximum, as well as fewer than the total number of strategies active in the vault. `withdrawalQueue` will be updated in a gas-efficient manner, assuming the input is well- ordered with 0x0 only at the end. This may only be called by governance or management.    
+Updates the withdrawalQueue to match the addresses and order specified by `queue`. There can be fewer strategies than the maximum, as well as fewer than the total number of strategies active in the vault. `withdrawalQueue` will be updated in a gas-efficient manner, assuming the input is well- ordered with 0x0 only at the end. This may only be called by governance or management.    
 
 
 *This is order sensitive, specify the addresses in the order in which funds should be withdrawn (so `queue`[0] is the first Strategy withdrawn from, `queue`[1] is the second, etc.) This means that the least impactful Strategy (the Strategy that will have its core positions impacted the least by having funds removed) should be at `queue`[0], then the next least impactful at `queue`[1], and so on.*
@@ -389,7 +389,7 @@ function transfer(address,uint256)
 ```
 
 
-@notice Transfers shares from the caller&#39;s address to `receiver`. This function will always return true, unless the user is attempting to transfer shares to this contract&#39;s address, or to 0x0.    
+Transfers shares from the caller&#39;s address to `receiver`. This function will always return true, unless the user is attempting to transfer shares to this contract&#39;s address, or to 0x0.    
 
 
 
@@ -417,7 +417,7 @@ function transferFrom(address,address,uint256)
 ```
 
 
-@notice Transfers `amount` shares from `sender` to `receiver`. This operation will always return true, unless the user is attempting to transfer shares to this contract&#39;s address, or to 0x0. Unless the caller has given this contract unlimited approval, transfering shares will decrement the caller&#39;s `allowance` by `amount`.    
+Transfers `amount` shares from `sender` to `receiver`. This operation will always return true, unless the user is attempting to transfer shares to this contract&#39;s address, or to 0x0. Unless the caller has given this contract unlimited approval, transfering shares will decrement the caller&#39;s `allowance` by `amount`.    
 
 
 
@@ -512,7 +512,7 @@ function permit(address,address,uint256,uint256,bytes)
 ```
 
 
-@notice Approves spender by owner&#39;s signature to expend owner&#39;s tokens. See https://eips.ethereum.org/EIPS/eip-2612.    
+Approves spender by owner&#39;s signature to expend owner&#39;s tokens. See https://eips.ethereum.org/EIPS/eip-2612.    
 
 
 
@@ -543,7 +543,7 @@ function totalAssets()
 ```
 
 
-@notice Returns the total quantity of all assets under control of this Vault, whether they&#39;re loaned out to a Strategy, or currently held in the Vault.    
+Returns the total quantity of all assets under control of this Vault, whether they&#39;re loaned out to a Strategy, or currently held in the Vault.    
 
 
 
@@ -564,7 +564,7 @@ function deposit()
 ```
 
 
-@notice Deposits `_amount` `token`, issuing shares to `recipient`. If the Vault is in Emergency Shutdown, deposits will not be accepted and this call will fail.    
+Deposits `_amount` `token`, issuing shares to `recipient`. If the Vault is in Emergency Shutdown, deposits will not be accepted and this call will fail.    
 
 
 *Measuring quantity of shares to issues is based on the total outstanding debt that this contract has (&#34;expected value&#34;) instead of the total balance sheet it has (&#34;estimated value&#34;) has important security considerations, and is done intentionally. If this value were measured against external systems, it could be purposely manipulated by an attacker to withdraw more assets than they otherwise should be able to claim by redeeming their shares. On deposit, this means that shares are issued against the total amount that the deposited capital can be given in service of the debt that Strategies assume. If that number were to be lower than the &#34;expected value&#34; at some future point, depositing shares via this method could entitle the depositor to *less* than the deposited value once the &#34;realized value&#34; is updated from further reports by the Strategies to the Vaults. Care should be taken by integrators to account for this discrepancy, by using the view-only methods of this contract (both off-chain and on-chain) to determine if depositing into the Vault is a &#34;good idea&#34;.*
@@ -650,7 +650,7 @@ function maxAvailableShares()
 ```
 
 
-@notice Determines the maximum quantity of shares this Vault can facilitate a withdrawal for, factoring in assets currently residing in the Vault, as well as those deployed to strategies on the Vault&#39;s balance sheet.    
+Determines the maximum quantity of shares this Vault can facilitate a withdrawal for, factoring in assets currently residing in the Vault, as well as those deployed to strategies on the Vault&#39;s balance sheet.    
 
 
 *Regarding how shares are calculated, see dev note on `deposit`. If you want to calculated the maximum a user could withdraw up to, you want to use this function. Note that the amount provided by this function is the theoretical maximum possible from withdrawing, the real amount depends on the realized losses incurred during withdrawal.*
@@ -673,7 +673,7 @@ function withdraw()
 ```
 
 
-@notice Withdraws the calling account&#39;s tokens from this Vault, redeeming amount `_shares` for an appropriate amount of tokens. See note on `setWithdrawalQueue` for further details of withdrawal ordering and behavior.    
+Withdraws the calling account&#39;s tokens from this Vault, redeeming amount `_shares` for an appropriate amount of tokens. See note on `setWithdrawalQueue` for further details of withdrawal ordering and behavior.    
 
 
 *Measuring the value of shares is based on the total outstanding debt that this contract has (&#34;expected value&#34;) instead of the total balance sheet it has (&#34;estimated value&#34;) has important security considerations, and is done intentionally. If this value were measured against external systems, it could be purposely manipulated by an attacker to withdraw more assets than they otherwise should be able to claim by redeeming their shares. On withdrawal, this means that shares are redeemed against the total amount that the deposited capital had &#34;realized&#34; since the point it was deposited, up until the point it was withdrawn. If that number were to be higher than the &#34;expected value&#34; at some future point, withdrawing shares via this method could entitle the depositor to *more* than the expected value once the &#34;realized value&#34; is updated from further reports by the Strategies to the Vaults. Under exceptional scenarios, this could cause earlier withdrawals to earn &#34;more&#34; of the underlying assets than Users might otherwise be entitled to, if the Vault&#39;s estimated value were otherwise measured through external means, accounting for whatever exceptional scenarios exist for the Vault (that aren&#39;t covered by the Vault&#39;s own design.)*
@@ -791,7 +791,7 @@ function pricePerShare()
 ```
 
 
-@notice Gives the price for a single Vault share.    
+Gives the price for a single Vault share.    
 
 
 *See dev note on `withdraw`.*
@@ -814,7 +814,7 @@ function addStrategy(address,uint256,uint256,uint256,uint256)
 ```
 
 
-@notice Add a Strategy to the Vault. This may only be called by governance.    
+Add a Strategy to the Vault. This may only be called by governance.    
 
 
 *The Strategy will be appended to `withdrawalQueue`, call `setWithdrawalQueue` to change the order.*
@@ -841,7 +841,7 @@ function updateStrategyDebtRatio(address,uint256)
 ```
 
 
-@notice Change the quantity of assets `strategy` may manage. This may be called by governance or management.    
+Change the quantity of assets `strategy` may manage. This may be called by governance or management.    
 
 
 
@@ -863,7 +863,7 @@ function updateStrategyMinDebtPerHarvest(address,uint256)
 ```
 
 
-@notice Change the quantity assets per block this Vault may deposit to or withdraw from `strategy`. This may only be called by governance or management.    
+Change the quantity assets per block this Vault may deposit to or withdraw from `strategy`. This may only be called by governance or management.    
 
 
 
@@ -885,7 +885,7 @@ function updateStrategyMaxDebtPerHarvest(address,uint256)
 ```
 
 
-@notice Change the quantity assets per block this Vault may deposit to or withdraw from `strategy`. This may only be called by governance or management.    
+Change the quantity assets per block this Vault may deposit to or withdraw from `strategy`. This may only be called by governance or management.    
 
 
 
@@ -907,7 +907,7 @@ function updateStrategyPerformanceFee(address,uint256)
 ```
 
 
-@notice Change the fee the strategist will receive based on this Vault&#39;s performance. This may only be called by governance.    
+Change the fee the strategist will receive based on this Vault&#39;s performance. This may only be called by governance.    
 
 
 
@@ -929,7 +929,7 @@ function migrateStrategy(address,address)
 ```
 
 
-@notice Migrates a Strategy, including all assets from `oldVersion` to `newVersion`. This may only be called by governance.    
+Migrates a Strategy, including all assets from `oldVersion` to `newVersion`. This may only be called by governance.    
 
 
 *Strategy must successfully migrate all capital and positions to new Strategy, or else this will upset the balance of the Vault. The new Strategy should be &#34;empty&#34; e.g. have no prior commitments to this Vault, otherwise it could have issues.*
@@ -953,7 +953,7 @@ function revokeStrategy()
 ```
 
 
-@notice Revoke a Strategy, setting its debt limit to 0 and preventing any future deposits. This function should only be used in the scenario where the Strategy is being retired but no migration of the positions are possible, or in the extreme scenario that the Strategy needs to be put into &#34;Emergency Exit&#34; mode in order for it to exit as quickly as possible. The latter scenario could be for any reason that is considered &#34;critical&#34; that the Strategy exits its position as fast as possible, such as a sudden change in market conditions leading to losses, or an imminent failure in an external dependency. This may only be called by governance, the guardian, or the Strategy itself. Note that a Strategy will only revoke itself during emergency shutdown.    
+Revoke a Strategy, setting its debt limit to 0 and preventing any future deposits. This function should only be used in the scenario where the Strategy is being retired but no migration of the positions are possible, or in the extreme scenario that the Strategy needs to be put into &#34;Emergency Exit&#34; mode in order for it to exit as quickly as possible. The latter scenario could be for any reason that is considered &#34;critical&#34; that the Strategy exits its position as fast as possible, such as a sudden change in market conditions leading to losses, or an imminent failure in an external dependency. This may only be called by governance, the guardian, or the Strategy itself. Note that a Strategy will only revoke itself during emergency shutdown.    
 
 
 
@@ -993,7 +993,7 @@ function addStrategyToQueue(address)
 ```
 
 
-@notice Adds `strategy` to `withdrawalQueue`. This may only be called by governance or management.    
+Adds `strategy` to `withdrawalQueue`. This may only be called by governance or management.    
 
 
 *The Strategy will be appended to `withdrawalQueue`, call `setWithdrawalQueue` to change the order.*
@@ -1016,7 +1016,7 @@ function removeStrategyFromQueue(address)
 ```
 
 
-@notice Remove `strategy` from `withdrawalQueue`. This may only be called by governance or management.    
+Remove `strategy` from `withdrawalQueue`. This may only be called by governance or management.    
 
 
 *We don&#39;t do this with revokeStrategy because it should still be possible to withdraw from the Strategy if it&#39;s unwinding.*
@@ -1039,7 +1039,7 @@ function debtOutstanding()
 ```
 
 
-@notice Determines if `strategy` is past its debt limit and if any tokens should be withdrawn to the Vault.    
+Determines if `strategy` is past its debt limit and if any tokens should be withdrawn to the Vault.    
 
 
 
@@ -1091,7 +1091,7 @@ function creditAvailable()
 ```
 
 
-@notice Amount of tokens in Vault a Strategy has access to as a credit line. This will check the Strategy&#39;s debt limit, as well as the tokens available in the Vault, and determine the maximum amount of tokens (if any) the Strategy may draw on. In the rare case the Vault is in emergency shutdown this will return 0.    
+Amount of tokens in Vault a Strategy has access to as a credit line. This will check the Strategy&#39;s debt limit, as well as the tokens available in the Vault, and determine the maximum amount of tokens (if any) the Strategy may draw on. In the rare case the Vault is in emergency shutdown this will return 0.    
 
 
 
@@ -1143,7 +1143,7 @@ function expectedReturn()
 ```
 
 
-@notice Provide an accurate expected value for the return this `strategy` would provide to the Vault the next time `report()` is called (since the last time it was called).    
+Provide an accurate expected value for the return this `strategy` would provide to the Vault the next time `report()` is called (since the last time it was called).    
 
 
 
@@ -1195,7 +1195,7 @@ function report(uint256,uint256,uint256)
 ```
 
 
-@notice Reports the amount of assets the calling Strategy has free (usually in terms of ROI). The performance fee is determined here, off of the strategy&#39;s profits (if any), and sent to governance. The strategist&#39;s fee is also determined here (off of profits), to be handled according to the strategist on the next harvest. This may only be called by a Strategy managed by this Vault.    
+Reports the amount of assets the calling Strategy has free (usually in terms of ROI). The performance fee is determined here, off of the strategy&#39;s profits (if any), and sent to governance. The strategist&#39;s fee is also determined here (off of profits), to be handled according to the strategist on the next harvest. This may only be called by a Strategy managed by this Vault.    
 
 
 *For approved strategies, this is the most efficient behavior. The Strategy reports back what it has free, then Vault &#34;decides&#34; whether to take some back or give it more. Note that the most it can take is `gain + _debtPayment`, and the most it can give is all of the remaining reserves. Anything outside of those bounds is abnormal behavior. All approved strategies must have increased diligence around calling this function, as abnormal behavior could become catastrophic.*
@@ -1226,7 +1226,7 @@ function sweep(address)
 ```
 
 
-@notice Removes tokens from this Vault that are not the type of token managed by this Vault. This may be used in case of accidentally sending the wrong kind of token to this Vault. Tokens will be sent to `governance`. This will fail if an attempt is made to sweep the tokens that this Vault manages. This may only be called by governance.    
+Removes tokens from this Vault that are not the type of token managed by this Vault. This may be used in case of accidentally sending the wrong kind of token to this Vault. Tokens will be sent to `governance`. This will fail if an attempt is made to sweep the tokens that this Vault manages. This may only be called by governance.    
 
 
 

--- a/versioned_docs/version-0.4.2/smart-contracts/BaseStrategy.md
+++ b/versioned_docs/version-0.4.2/smart-contracts/BaseStrategy.md
@@ -8,7 +8,7 @@
   function apiVersion(
   ) public returns (string)
 ```
-@notice
+
  Used to track which version of `StrategyAPI` this Strategy
  implements.
 
@@ -41,7 +41,7 @@ This Strategy's name.
   function delegatedAssets(
   ) external returns (uint256)
 ```
-@notice
+
  The amount (priced in want) of the total assets managed by this strategy should not count
  towards Yearn's TVL calculations.
 @dev
@@ -75,7 +75,7 @@ This Strategy's name.
     address _keeper
   ) internal
 ```
-@notice
+
  Initializes the Strategy, this is called only once, when the
  contract is deployed.
 
@@ -97,7 +97,7 @@ can harvest and tend a strategy.
     address _strategist
   ) external
 ```
-@notice
+
  Used to change `strategist`.
 
  This may only be called by governance or the existing strategist.
@@ -114,7 +114,7 @@ can harvest and tend a strategy.
     address _keeper
   ) external
 ```
-@notice
+
  Used to change `keeper`.
 
  `keeper` is the only address that may call `tend()` or `harvest()`,
@@ -137,7 +137,7 @@ can harvest and tend a strategy.
     address _rewards
   ) external
 ```
-@notice
+
  Used to change `rewards`. EOA or smart contract which has the permission
  to pull rewards from the vault.
 
@@ -155,7 +155,7 @@ can harvest and tend a strategy.
     uint256 _delay
   ) external
 ```
-@notice
+
  Used to change `minReportDelay`. `minReportDelay` is the minimum number
  of blocks that should pass for `harvest()` to be called.
 
@@ -177,7 +177,7 @@ can harvest and tend a strategy.
     uint256 _delay
   ) external
 ```
-@notice
+
  Used to change `maxReportDelay`. `maxReportDelay` is the maximum number
  of blocks that should pass for `harvest()` to be called.
 
@@ -199,7 +199,7 @@ can harvest and tend a strategy.
     uint256 _profitFactor
   ) external
 ```
-@notice
+
  Used to change `profitFactor`. `profitFactor` is used to determine
  if it's worthwhile to harvest, given gas costs. (See `harvestTrigger()`
  for more details.)
@@ -219,7 +219,7 @@ can harvest and tend a strategy.
     uint256 _debtThreshold
   ) external
 ```
-@notice
+
  Sets how far the Strategy can go into loss without a harvest and report
  being required.
 
@@ -242,7 +242,7 @@ being required to report to the Vault.
     string _metadataURI
   ) external
 ```
-@notice
+
  Used to change `metadataURI`. `metadataURI` is used to store the URI
 of the file describing the strategy.
 
@@ -270,7 +270,7 @@ on protected functions in the Strategy.
     uint256 _amtInWei
   ) public returns (uint256)
 ```
-@notice
+
  Provide an accurate conversion from `_amtInWei` (denominated in wei)
  to `want` (using the native decimal characteristics of `want`).
 @dev
@@ -297,7 +297,7 @@ on protected functions in the Strategy.
   function estimatedTotalAssets(
   ) public returns (uint256)
 ```
-@notice
+
  Provide an accurate estimate for the total amount of assets
  (principle + return) that this Strategy is currently managing,
  denominated in terms of `want` tokens.
@@ -412,7 +412,7 @@ liquidate all of the Strategy's positions back to the Vault.
     uint256 callCostInWei
   ) public returns (bool)
 ```
-@notice
+
  Provide a signal to the keeper that `tend()` should be called. The
  keeper will provide the estimated gas cost that they would pay to call
  `tend()`, and this function should use that estimate to make a
@@ -442,7 +442,7 @@ liquidate all of the Strategy's positions back to the Vault.
   function tend(
   ) external
 ```
-@notice
+
  Adjust the Strategy's position. The purpose of tending isn't to
  realize gains, but to maximize yield by reinvesting any returns.
 
@@ -458,7 +458,7 @@ liquidate all of the Strategy's positions back to the Vault.
     uint256 callCostInWei
   ) public returns (bool)
 ```
-@notice
+
  Provide a signal to the keeper that `harvest()` should be called. The
  keeper will provide the estimated gas cost that they would pay to call
  `harvest()`, and this function should use that estimate to make a
@@ -500,7 +500,7 @@ liquidate all of the Strategy's positions back to the Vault.
   function harvest(
   ) external
 ```
-@notice
+
  Harvests the Strategy, recognizing any profits or losses and adjusting
  the Strategy's position.
 
@@ -524,7 +524,7 @@ liquidate all of the Strategy's positions back to the Vault.
     uint256 _amountNeeded
   ) external returns (uint256 _loss)
 ```
-@notice
+
  Withdraws `_amountNeeded` to `vault`.
 
  This may only be called by the Vault.
@@ -556,7 +556,7 @@ value.
     address _newStrategy
   ) external
 ```
-@notice
+
  Transfers all `want` from this Strategy to `_newStrategy`.
 
  This may only be called by the Vault.
@@ -577,7 +577,7 @@ interacted with the vault before.
   function setEmergencyExit(
   ) external
 ```
-@notice
+
  Activates emergency exit. Once activated, the Strategy will exit its
  position upon the next harvest, depositing all funds into the Vault as
  quickly as is reasonable given on-chain conditions.
@@ -618,7 +618,7 @@ Example:
     address _token
   ) external
 ```
-@notice
+
  Removes tokens from this Strategy that are not the type of tokens
  managed by this Strategy. This may be used in case of accidentally
  sending the wrong kind of token to this Strategy.

--- a/versioned_docs/version-0.4.2/smart-contracts/BaseWrapper.md
+++ b/versioned_docs/version-0.4.2/smart-contracts/BaseWrapper.md
@@ -18,7 +18,7 @@
     address _registry
   ) external
 ```
-@notice
+
  Used to update the yearn registry.
 
 
@@ -32,7 +32,7 @@
   function bestVault(
   ) public returns (contract VaultAPI)
 ```
-@notice
+
  Used to get the most revent vault for the token using the registry.
 
 
@@ -46,7 +46,7 @@
   function allVaults(
   ) public returns (contract VaultAPI[])
 ```
-@notice
+
  Used to get all vaults from the registery for the token
 
 
@@ -69,7 +69,7 @@
   function totalVaultBalance(
   ) public returns (uint256 balance)
 ```
-@notice
+
  Used to get the balance of an account accross all the vaults for a token.
  @dev will be used to get the wrapper balance using totalVaultBalance(address(this)).
  @param account The address of the account.
@@ -82,7 +82,7 @@
   function totalAssets(
   ) public returns (uint256 assets)
 ```
-@notice
+
  Used to get the TVL on the underlying vaults.
  @return assets the sum of all the assets managed by the underlying vaults.
 

--- a/versioned_docs/version-0.4.2/smart-contracts/registry.md
+++ b/versioned_docs/version-0.4.2/smart-contracts/registry.md
@@ -16,7 +16,7 @@ function setGovernance(address)
 ```
 
 
-@notice Starts the 1st phase of the governance transfer.    
+Starts the 1st phase of the governance transfer.    
 
 
 *Throws if the caller is not current governance.*
@@ -39,7 +39,7 @@ function acceptGovernance()
 ```
 
 
-@notice Completes the 2nd phase of the governance transfer.    
+Completes the 2nd phase of the governance transfer.    
 
 
 *Throws if the caller is not the pending caller. Emits a `NewGovernance` event.*
@@ -56,7 +56,7 @@ function latestRelease()
 ```
 
 
-@notice Returns the api version of the latest release.    
+Returns the api version of the latest release.    
 
 
 *Throws if no releases are registered yet.*
@@ -79,7 +79,7 @@ function latestVault(address)
 ```
 
 
-@notice Returns the latest deployed vault for the given token.    
+Returns the latest deployed vault for the given token.    
 
 
 *Throws if no vaults are endorsed yet for the given token.*
@@ -108,7 +108,7 @@ function newRelease(address)
 ```
 
 
-@notice Add a previously deployed Vault as the template contract for the latest release, to be used by further &#34;forwarder-style&#34; delegatecall proxy contracts that can be deployed from the registry throw other methods (to save gas).    
+Add a previously deployed Vault as the template contract for the latest release, to be used by further &#34;forwarder-style&#34; delegatecall proxy contracts that can be deployed from the registry throw other methods (to save gas).    
 
 
 *Throws if caller isn&#39;t `self.governance`. Throws if `vault`&#39;s governance isn&#39;t `self.governance`. Throws if the api version is the same as the previous release. Emits a `NewVault` event.*
@@ -131,7 +131,7 @@ function newVault(address,address,address,string,string)
 ```
 
 
-@notice Create a new vault for the given token using the latest release in the registry, as a simple &#34;forwarder-style&#34; delegatecall proxy to the latest release. Also adds the new vault to the list of &#34;endorsed&#34; vaults for that token.    
+Create a new vault for the given token using the latest release in the registry, as a simple &#34;forwarder-style&#34; delegatecall proxy to the latest release. Also adds the new vault to the list of &#34;endorsed&#34; vaults for that token.    
 
 
 *`governance` is set in the new vault as `self.governance`, with no ability to override. Throws if caller isn&#39;t `self.governance`. Throws if no releases are registered yet. Throws if there already is a registered vault for the given token with the latest api version. Emits a `NewVault` event.*
@@ -197,7 +197,7 @@ function newExperimentalVault(address,address,address,address,string,string)
 ```
 
 
-@notice Create a new vault for the given token using the latest release in the registry, as a simple &#34;forwarder-style&#34; delegatecall proxy to the latest release. Does not add the new vault to the list of &#34;endorsed&#34; vaults for that token.    
+Create a new vault for the given token using the latest release in the registry, as a simple &#34;forwarder-style&#34; delegatecall proxy to the latest release. Does not add the new vault to the list of &#34;endorsed&#34; vaults for that token.    
 
 
 *Throws if no releases are registered yet. Emits a `NewExperimentalVault` event.*
@@ -265,7 +265,7 @@ function endorseVault(address)
 ```
 
 
-@notice Adds an existing vault to the list of &#34;endorsed&#34; vaults for that token.    
+Adds an existing vault to the list of &#34;endorsed&#34; vaults for that token.    
 
 
 *`governance` is set in the new vault as `self.governance`, with no ability to override. Throws if caller isn&#39;t `self.governance`. Throws if `vault`&#39;s governance isn&#39;t `self.governance`. Throws if no releases are registered yet. Throws if `vault`&#39;s api version does not match latest release. Throws if there already is a deployment for the vault&#39;s token with the latest api version. Emits a `NewVault` event.*
@@ -311,7 +311,7 @@ function setBanksy(address)
 ```
 
 
-@notice Set the ability of a particular tagger to tag current vaults.    
+Set the ability of a particular tagger to tag current vaults.    
 
 
 *Throws if caller is not `self.governance`.*
@@ -357,7 +357,7 @@ function tagVault(address,string)
 ```
 
 
-@notice Tag a Vault with a message.    
+Tag a Vault with a message.    
 
 
 *Throws if caller is not `self.governance` or an approved tagger. Emits a `VaultTagged` event.*

--- a/versioned_docs/version-0.4.2/smart-contracts/vault.md
+++ b/versioned_docs/version-0.4.2/smart-contracts/vault.md
@@ -20,7 +20,7 @@ function initialize(address,address,address,string,string)
 ```
 
 
-@notice Initializes the Vault, this is called only once, when the contract is deployed. The performance fee is set to 10% of yield, per Strategy. The management fee is set to 2%, per year. The initial deposit limit is set to 0 (deposits disabled); it must be updated after initialization.    
+Initializes the Vault, this is called only once, when the contract is deployed. The performance fee is set to 10% of yield, per Strategy. The management fee is set to 2%, per year. The initial deposit limit is set to 0 (deposits disabled); it must be updated after initialization.    
 
 
 *If `nameOverride` is not specified, the name will be &#39;yearn&#39; combined with the name of `token`. If `symbolOverride` is not specified, the symbol will be &#39;yv&#39; combined with the symbol of `token`. The token used by the vault should not change balances outside transfers and it must transfer the exact amount requested. Fee on transfer and rebasing are not supported.*
@@ -103,7 +103,7 @@ function apiVersion()
 ```
 
 
-@notice Used to track the deployed version of this contract. In practice you can use this version number to compare with Yearn&#39;s GitHub and determine which version of the source matches this deployed contract.    
+Used to track the deployed version of this contract. In practice you can use this version number to compare with Yearn&#39;s GitHub and determine which version of the source matches this deployed contract.    
 
 
 *All strategies must have an `apiVersion()` that matches the Vault&#39;s `API_VERSION`.*
@@ -126,7 +126,7 @@ function setName(string)
 ```
 
 
-@notice Used to change the value of `name`. This may only be called by governance.    
+Used to change the value of `name`. This may only be called by governance.    
 
 
 
@@ -147,7 +147,7 @@ function setSymbol(string)
 ```
 
 
-@notice Used to change the value of `symbol`. This may only be called by governance.    
+Used to change the value of `symbol`. This may only be called by governance.    
 
 
 
@@ -168,7 +168,7 @@ function setGovernance(address)
 ```
 
 
-@notice Nominate a new address to use as governance. The change does not go into effect immediately. This function sets a pending change, and the governance address is not updated until the proposed governance address has accepted the responsibility. This may only be called by the current governance address.    
+Nominate a new address to use as governance. The change does not go into effect immediately. This function sets a pending change, and the governance address is not updated until the proposed governance address has accepted the responsibility. This may only be called by the current governance address.    
 
 
 
@@ -189,7 +189,7 @@ function acceptGovernance()
 ```
 
 
-@notice Once a new governance address has been proposed using setGovernance(), this function may be called by the proposed address to accept the responsibility of taking over governance for this contract. This may only be called by the proposed governance address.    
+Once a new governance address has been proposed using setGovernance(), this function may be called by the proposed address to accept the responsibility of taking over governance for this contract. This may only be called by the proposed governance address.    
 
 
 *setGovernance() should be called by the existing governance address, prior to calling this function.*
@@ -206,7 +206,7 @@ function setManagement(address)
 ```
 
 
-@notice Changes the management address. Management is able to make some investment decisions adjusting parameters. This may only be called by governance.    
+Changes the management address. Management is able to make some investment decisions adjusting parameters. This may only be called by governance.    
 
 
 
@@ -227,7 +227,7 @@ function setRewards(address)
 ```
 
 
-@notice Changes the rewards address. Any distributed rewards will cease flowing to the old address and begin flowing to this address once the change is in effect. This will not change any Strategy reports in progress, only new reports made after this change goes into effect. This may only be called by governance.    
+Changes the rewards address. Any distributed rewards will cease flowing to the old address and begin flowing to this address once the change is in effect. This will not change any Strategy reports in progress, only new reports made after this change goes into effect. This may only be called by governance.    
 
 
 
@@ -248,7 +248,7 @@ function setLockedProfitDegradation(uint256)
 ```
 
 
-@notice Changes the locked profit degradation.    
+Changes the locked profit degradation.    
 
 
 
@@ -269,7 +269,7 @@ function setDepositLimit(uint256)
 ```
 
 
-@notice Changes the maximum amount of tokens that can be deposited in this Vault. Note, this is not how much may be deposited by a single depositor, but the maximum amount that may be deposited across all depositors. This may only be called by governance.    
+Changes the maximum amount of tokens that can be deposited in this Vault. Note, this is not how much may be deposited by a single depositor, but the maximum amount that may be deposited across all depositors. This may only be called by governance.    
 
 
 
@@ -290,7 +290,7 @@ function setPerformanceFee(uint256)
 ```
 
 
-@notice Used to change the value of `performanceFee`. Should set this value below the maximum strategist performance fee. This may only be called by governance.    
+Used to change the value of `performanceFee`. Should set this value below the maximum strategist performance fee. This may only be called by governance.    
 
 
 
@@ -311,7 +311,7 @@ function setManagementFee(uint256)
 ```
 
 
-@notice Used to change the value of `managementFee`. This may only be called by governance.    
+Used to change the value of `managementFee`. This may only be called by governance.    
 
 
 
@@ -332,7 +332,7 @@ function setGuardian(address)
 ```
 
 
-@notice Used to change the address of `guardian`. This may only be called by governance or the existing guardian.    
+Used to change the address of `guardian`. This may only be called by governance or the existing guardian.    
 
 
 
@@ -353,7 +353,7 @@ function setEmergencyShutdown(bool)
 ```
 
 
-@notice Activates or deactivates Vault mode where all Strategies go into full withdrawal. During Emergency Shutdown: 1. No Users may deposit into the Vault (but may withdraw as usual.) 2. Governance may not add new Strategies. 3. Each Strategy must pay back their debt as quickly as reasonable to minimally affect their position. 4. Only Governance may undo Emergency Shutdown. See contract level note for further details. This may only be called by governance or the guardian.    
+Activates or deactivates Vault mode where all Strategies go into full withdrawal. During Emergency Shutdown: 1. No Users may deposit into the Vault (but may withdraw as usual.) 2. Governance may not add new Strategies. 3. Each Strategy must pay back their debt as quickly as reasonable to minimally affect their position. 4. Only Governance may undo Emergency Shutdown. See contract level note for further details. This may only be called by governance or the guardian.    
 
 
 
@@ -374,7 +374,7 @@ function setWithdrawalQueue(address[20])
 ```
 
 
-@notice Updates the withdrawalQueue to match the addresses and order specified by `queue`. There can be fewer strategies than the maximum, as well as fewer than the total number of strategies active in the vault. `withdrawalQueue` will be updated in a gas-efficient manner, assuming the input is well- ordered with 0x0 only at the end. This may only be called by governance or management.    
+Updates the withdrawalQueue to match the addresses and order specified by `queue`. There can be fewer strategies than the maximum, as well as fewer than the total number of strategies active in the vault. `withdrawalQueue` will be updated in a gas-efficient manner, assuming the input is well- ordered with 0x0 only at the end. This may only be called by governance or management.    
 
 
 *This is order sensitive, specify the addresses in the order in which funds should be withdrawn (so `queue`[0] is the first Strategy withdrawn from, `queue`[1] is the second, etc.) This means that the least impactful Strategy (the Strategy that will have its core positions impacted the least by having funds removed) should be at `queue`[0], then the next least impactful at `queue`[1], and so on.*
@@ -397,7 +397,7 @@ function transfer(address,uint256)
 ```
 
 
-@notice Transfers shares from the caller&#39;s address to `receiver`. This function will always return true, unless the user is attempting to transfer shares to this contract&#39;s address, or to 0x0.    
+Transfers shares from the caller&#39;s address to `receiver`. This function will always return true, unless the user is attempting to transfer shares to this contract&#39;s address, or to 0x0.    
 
 
 
@@ -425,7 +425,7 @@ function transferFrom(address,address,uint256)
 ```
 
 
-@notice Transfers `amount` shares from `sender` to `receiver`. This operation will always return true, unless the user is attempting to transfer shares to this contract&#39;s address, or to 0x0. Unless the caller has given this contract unlimited approval, transfering shares will decrement the caller&#39;s `allowance` by `amount`.    
+Transfers `amount` shares from `sender` to `receiver`. This operation will always return true, unless the user is attempting to transfer shares to this contract&#39;s address, or to 0x0. Unless the caller has given this contract unlimited approval, transfering shares will decrement the caller&#39;s `allowance` by `amount`.    
 
 
 
@@ -520,7 +520,7 @@ function permit(address,address,uint256,uint256,bytes)
 ```
 
 
-@notice Approves spender by owner&#39;s signature to expend owner&#39;s tokens. See https://eips.ethereum.org/EIPS/eip-2612.    
+Approves spender by owner&#39;s signature to expend owner&#39;s tokens. See https://eips.ethereum.org/EIPS/eip-2612.    
 
 
 
@@ -551,7 +551,7 @@ function totalAssets()
 ```
 
 
-@notice Returns the total quantity of all assets under control of this Vault, whether they&#39;re loaned out to a Strategy, or currently held in the Vault.    
+Returns the total quantity of all assets under control of this Vault, whether they&#39;re loaned out to a Strategy, or currently held in the Vault.    
 
 
 
@@ -572,7 +572,7 @@ function deposit()
 ```
 
 
-@notice Deposits `_amount` `token`, issuing shares to `recipient`. If the Vault is in Emergency Shutdown, deposits will not be accepted and this call will fail.    
+Deposits `_amount` `token`, issuing shares to `recipient`. If the Vault is in Emergency Shutdown, deposits will not be accepted and this call will fail.    
 
 
 *Measuring quantity of shares to issues is based on the total outstanding debt that this contract has (&#34;expected value&#34;) instead of the total balance sheet it has (&#34;estimated value&#34;) has important security considerations, and is done intentionally. If this value were measured against external systems, it could be purposely manipulated by an attacker to withdraw more assets than they otherwise should be able to claim by redeeming their shares. On deposit, this means that shares are issued against the total amount that the deposited capital can be given in service of the debt that Strategies assume. If that number were to be lower than the &#34;expected value&#34; at some future point, depositing shares via this method could entitle the depositor to *less* than the deposited value once the &#34;realized value&#34; is updated from further reports by the Strategies to the Vaults. Care should be taken by integrators to account for this discrepancy, by using the view-only methods of this contract (both off-chain and on-chain) to determine if depositing into the Vault is a &#34;good idea&#34;.*
@@ -658,7 +658,7 @@ function maxAvailableShares()
 ```
 
 
-@notice Determines the maximum quantity of shares this Vault can facilitate a withdrawal for, factoring in assets currently residing in the Vault, as well as those deployed to strategies on the Vault&#39;s balance sheet.    
+Determines the maximum quantity of shares this Vault can facilitate a withdrawal for, factoring in assets currently residing in the Vault, as well as those deployed to strategies on the Vault&#39;s balance sheet.    
 
 
 *Regarding how shares are calculated, see dev note on `deposit`. If you want to calculated the maximum a user could withdraw up to, you want to use this function. Note that the amount provided by this function is the theoretical maximum possible from withdrawing, the real amount depends on the realized losses incurred during withdrawal.*
@@ -681,7 +681,7 @@ function withdraw()
 ```
 
 
-@notice Withdraws the calling account&#39;s tokens from this Vault, redeeming amount `_shares` for an appropriate amount of tokens. See note on `setWithdrawalQueue` for further details of withdrawal ordering and behavior.    
+Withdraws the calling account&#39;s tokens from this Vault, redeeming amount `_shares` for an appropriate amount of tokens. See note on `setWithdrawalQueue` for further details of withdrawal ordering and behavior.    
 
 
 *Measuring the value of shares is based on the total outstanding debt that this contract has (&#34;expected value&#34;) instead of the total balance sheet it has (&#34;estimated value&#34;) has important security considerations, and is done intentionally. If this value were measured against external systems, it could be purposely manipulated by an attacker to withdraw more assets than they otherwise should be able to claim by redeeming their shares. On withdrawal, this means that shares are redeemed against the total amount that the deposited capital had &#34;realized&#34; since the point it was deposited, up until the point it was withdrawn. If that number were to be higher than the &#34;expected value&#34; at some future point, withdrawing shares via this method could entitle the depositor to *more* than the expected value once the &#34;realized value&#34; is updated from further reports by the Strategies to the Vaults. Under exceptional scenarios, this could cause earlier withdrawals to earn &#34;more&#34; of the underlying assets than Users might otherwise be entitled to, if the Vault&#39;s estimated value were otherwise measured through external means, accounting for whatever exceptional scenarios exist for the Vault (that aren&#39;t covered by the Vault&#39;s own design.) In the situation where a large withdrawal happens, it can empty the vault balance and the strategies in the withdrawal queue. Strategies not in the withdrawal queue will have to be harvested to rebalance the funds and make the funds available again to withdraw.*
@@ -799,7 +799,7 @@ function pricePerShare()
 ```
 
 
-@notice Gives the price for a single Vault share.    
+Gives the price for a single Vault share.    
 
 
 *See dev note on `withdraw`.*
@@ -822,7 +822,7 @@ function addStrategy(address,uint256,uint256,uint256,uint256)
 ```
 
 
-@notice Add a Strategy to the Vault. This may only be called by governance.    
+Add a Strategy to the Vault. This may only be called by governance.    
 
 
 *The Strategy will be appended to `withdrawalQueue`, call `setWithdrawalQueue` to change the order.*
@@ -849,7 +849,7 @@ function updateStrategyDebtRatio(address,uint256)
 ```
 
 
-@notice Change the quantity of assets `strategy` may manage. This may be called by governance or management.    
+Change the quantity of assets `strategy` may manage. This may be called by governance or management.    
 
 
 
@@ -871,7 +871,7 @@ function updateStrategyMinDebtPerHarvest(address,uint256)
 ```
 
 
-@notice Change the quantity assets per block this Vault may deposit to or withdraw from `strategy`. This may only be called by governance or management.    
+Change the quantity assets per block this Vault may deposit to or withdraw from `strategy`. This may only be called by governance or management.    
 
 
 
@@ -893,7 +893,7 @@ function updateStrategyMaxDebtPerHarvest(address,uint256)
 ```
 
 
-@notice Change the quantity assets per block this Vault may deposit to or withdraw from `strategy`. This may only be called by governance or management.    
+Change the quantity assets per block this Vault may deposit to or withdraw from `strategy`. This may only be called by governance or management.    
 
 
 
@@ -915,7 +915,7 @@ function updateStrategyPerformanceFee(address,uint256)
 ```
 
 
-@notice Change the fee the strategist will receive based on this Vault&#39;s performance. This may only be called by governance.    
+Change the fee the strategist will receive based on this Vault&#39;s performance. This may only be called by governance.    
 
 
 
@@ -937,7 +937,7 @@ function migrateStrategy(address,address)
 ```
 
 
-@notice Migrates a Strategy, including all assets from `oldVersion` to `newVersion`. This may only be called by governance.    
+Migrates a Strategy, including all assets from `oldVersion` to `newVersion`. This may only be called by governance.    
 
 
 *Strategy must successfully migrate all capital and positions to new Strategy, or else this will upset the balance of the Vault. The new Strategy should be &#34;empty&#34; e.g. have no prior commitments to this Vault, otherwise it could have issues.*
@@ -961,7 +961,7 @@ function revokeStrategy()
 ```
 
 
-@notice Revoke a Strategy, setting its debt limit to 0 and preventing any future deposits. This function should only be used in the scenario where the Strategy is being retired but no migration of the positions are possible, or in the extreme scenario that the Strategy needs to be put into &#34;Emergency Exit&#34; mode in order for it to exit as quickly as possible. The latter scenario could be for any reason that is considered &#34;critical&#34; that the Strategy exits its position as fast as possible, such as a sudden change in market conditions leading to losses, or an imminent failure in an external dependency. This may only be called by governance, the guardian, or the Strategy itself. Note that a Strategy will only revoke itself during emergency shutdown.    
+Revoke a Strategy, setting its debt limit to 0 and preventing any future deposits. This function should only be used in the scenario where the Strategy is being retired but no migration of the positions are possible, or in the extreme scenario that the Strategy needs to be put into &#34;Emergency Exit&#34; mode in order for it to exit as quickly as possible. The latter scenario could be for any reason that is considered &#34;critical&#34; that the Strategy exits its position as fast as possible, such as a sudden change in market conditions leading to losses, or an imminent failure in an external dependency. This may only be called by governance, the guardian, or the Strategy itself. Note that a Strategy will only revoke itself during emergency shutdown.    
 
 
 
@@ -1001,7 +1001,7 @@ function addStrategyToQueue(address)
 ```
 
 
-@notice Adds `strategy` to `withdrawalQueue`. This may only be called by governance or management.    
+Adds `strategy` to `withdrawalQueue`. This may only be called by governance or management.    
 
 
 *The Strategy will be appended to `withdrawalQueue`, call `setWithdrawalQueue` to change the order.*
@@ -1024,7 +1024,7 @@ function removeStrategyFromQueue(address)
 ```
 
 
-@notice Remove `strategy` from `withdrawalQueue`. This may only be called by governance or management.    
+Remove `strategy` from `withdrawalQueue`. This may only be called by governance or management.    
 
 
 *We don&#39;t do this with revokeStrategy because it should still be possible to withdraw from the Strategy if it&#39;s unwinding.*
@@ -1047,7 +1047,7 @@ function debtOutstanding()
 ```
 
 
-@notice Determines if `strategy` is past its debt limit and if any tokens should be withdrawn to the Vault.    
+Determines if `strategy` is past its debt limit and if any tokens should be withdrawn to the Vault.    
 
 
 
@@ -1099,7 +1099,7 @@ function creditAvailable()
 ```
 
 
-@notice Amount of tokens in Vault a Strategy has access to as a credit line. This will check the Strategy&#39;s debt limit, as well as the tokens available in the Vault, and determine the maximum amount of tokens (if any) the Strategy may draw on. In the rare case the Vault is in emergency shutdown this will return 0.    
+Amount of tokens in Vault a Strategy has access to as a credit line. This will check the Strategy&#39;s debt limit, as well as the tokens available in the Vault, and determine the maximum amount of tokens (if any) the Strategy may draw on. In the rare case the Vault is in emergency shutdown this will return 0.    
 
 
 
@@ -1151,7 +1151,7 @@ function expectedReturn()
 ```
 
 
-@notice Provide an accurate expected value for the return this `strategy` would provide to the Vault the next time `report()` is called (since the last time it was called).    
+Provide an accurate expected value for the return this `strategy` would provide to the Vault the next time `report()` is called (since the last time it was called).    
 
 
 
@@ -1203,7 +1203,7 @@ function report(uint256,uint256,uint256)
 ```
 
 
-@notice Reports the amount of assets the calling Strategy has free (usually in terms of ROI). The performance fee is determined here, off of the strategy&#39;s profits (if any), and sent to governance. The strategist&#39;s fee is also determined here (off of profits), to be handled according to the strategist on the next harvest. This may only be called by a Strategy managed by this Vault.    
+Reports the amount of assets the calling Strategy has free (usually in terms of ROI). The performance fee is determined here, off of the strategy&#39;s profits (if any), and sent to governance. The strategist&#39;s fee is also determined here (off of profits), to be handled according to the strategist on the next harvest. This may only be called by a Strategy managed by this Vault.    
 
 
 *For approved strategies, this is the most efficient behavior. The Strategy reports back what it has free, then Vault &#34;decides&#34; whether to take some back or give it more. Note that the most it can take is `gain + _debtPayment`, and the most it can give is all of the remaining reserves. Anything outside of those bounds is abnormal behavior. All approved strategies must have increased diligence around calling this function, as abnormal behavior could become catastrophic.*
@@ -1234,7 +1234,7 @@ function sweep(address)
 ```
 
 
-@notice Removes tokens from this Vault that are not the type of token managed by this Vault. This may be used in case of accidentally sending the wrong kind of token to this Vault. Tokens will be sent to `governance`. This will fail if an attempt is made to sweep the tokens that this Vault manages. This may only be called by governance.    
+Removes tokens from this Vault that are not the type of token managed by this Vault. This may be used in case of accidentally sending the wrong kind of token to this Vault. Tokens will be sent to `governance`. This will fail if an attempt is made to sweep the tokens that this Vault manages. This may only be called by governance.    
 
 
 


### PR DESCRIPTION
Removes `@notice` from the generated docs and also removes it from the template `contract.ejs` 
Issue: https://github.com/yearn/yearn-devdocs/issues/11