### PR TITLE
fix: make visited links visible and with the same color as not visited

### DIFF
--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -112,10 +112,6 @@ html[data-theme="light"] .textBox {
   border-color: rgba(128, 128, 128, 0.521);
 }
 
-a:visited {
-  color:inherit;
-}
-
 .learn {
   background-image: url("/static/img/learn.png");
   background-size:cover;


### PR DESCRIPTION
Finish the fix for #33 

Visited links were not showing. Below is a screenshot of how visited links look now.

<img width="582" alt="Screenshot 2021-08-31 at 10 28 27" src="https://user-images.githubusercontent.com/839844/131469349-9efcb98c-5549-45a9-8068-8bd2f9fe398f.png">
