### PR TITLE
fix typo

### DIFF
--- a/docs/contributing/documentation/writing-style-guide.md
+++ b/docs/contributing/documentation/writing-style-guide.md
@@ -177,7 +177,7 @@ When bulleted and numbered lists contain complete sentences, capitalize the firs
 
 - Use [absolute links](https://docs.microsoft.com/en-us/contribute/how-to-write-links) and standard web URLs when referencing external resources.
 - Create descriptive hyperlinks and avoid generic language.
-  - **Correct - Descriptive:** (Learn more at [Yearn Documentation](https://docs.yearn.finance/)
+  - **Correct - Descriptive:** Learn more at [Yearn Documentation](https://docs.yearn.finance/)
   - **Incorrect - Generic:** Learn more [here](https://docs.yearn.finance/).
 - Include a `.`outside the link for sentences that end with a link.
 - When creating links for parallel translated documents, make sure to update relative links to reflect the correct heading.


### PR DESCRIPTION
remove a lost `(`

<img width="640" alt="Screen Shot 2022-01-09 at 2 20 04 AM" src="https://user-images.githubusercontent.com/7863230/148670484-61974597-7e0b-497d-97ef-c753b8fde6ff.png">

