### PR TITLE
refactor: remove deprecated and private links

### DIFF
--- a/docs/developers/v2/EMERGENCY.md
+++ b/docs/developers/v2/EMERGENCY.md
@@ -48,8 +48,6 @@ Main responsibilities:
 - Prepare or help with transactions in different multi-sigs
   Reference:
   - [emergency-toolbox](https://github.com/yearn/emergency-toolbox)
-  - [CMO](https://github.com/yearn/chief-multisig-officer) - private
-  - [strategists-ms](https://github.com/yearn/strategist-ms) - private
 
 ### Strategist Lead
 

--- a/versioned_docs/version-0.4.3/smart-contracts/test/TestGuestList.md
+++ b/versioned_docs/version-0.4.3/smart-contracts/test/TestGuestList.md
@@ -1,9 +1,6 @@
 
 A basic guest list contract for testing.
 
-For a Vyper implementation of this contract containing additional
-functionality, see https://github.com/banteg/guest-list/blob/master/contracts/GuestList.vy
-
 ## Functions
 ### constructor
 ```solidity


### PR DESCRIPTION
removes the deprecated "GuestList" link from the latest version of the docs

close #127 

also removes private links from and close #125
