### PR TITLE
feature: add crowdin integration support

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,11 @@
+"project_id" : "493925"
+"api_token" : "CROWDIN_PERSONAL_TOKEN"
+"base_path" : "."
+"base_url" : "https://api.crowdin.com"
+"preserve_hierarchy": true
+files: [
+  {
+    source: '/docs/**/*',
+    translation: '/i18n/%two_letters_code%/**/%original_file_name%',
+  },
+]

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -9,6 +9,10 @@ module.exports = {
   baseUrl: '/',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
+  i18n: {
+    defaultLocale: 'en',
+    locales: ['pt'],
+  },
   favicon: 'img/favicon.ico',
   organizationName: 'yearn', // Usually your GitHub org/user name.
   projectName: 'yearn-devdocs', // Usually your repo name.
@@ -80,6 +84,10 @@ module.exports = {
         {
           type: 'search',
           position: 'right'
+        },
+        {
+          type: 'localeDropdown',
+          position: 'right',
         },
       ],
     },

--- a/package.json
+++ b/package.json
@@ -14,9 +14,12 @@
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "make-sol-doc": "solidity-docgen --templates=templates --helpers=helpers/solidityHelpers.js -i ../yearn-vaults/contracts/ -o docs/v2/smart-contracts",
-    "make-vyper-doc": "vydoc -i ../yearn-vaults/contracts/ -o docs/v2/smart-contracts -t ./templates/contract.ejs"
+    "make-vyper-doc": "vydoc -i ../yearn-vaults/contracts/ -o docs/v2/smart-contracts -t ./templates/contract.ejs",
+    "upload-translations": "crowdin upload sources --config crowdin.yml",
+    "download-translations": "crowdin download"
   },
   "dependencies": {
+    "@crowdin/cli": "^3.7.6",
     "@docusaurus/core": "2.0.0-beta.6",
     "@docusaurus/preset-classic": "2.0.0-beta.6",
     "@mdx-js/react": "^1.6.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1152,6 +1152,13 @@
   dependencies:
     arrify "^1.0.1"
 
+"@crowdin/cli@^3.7.6":
+  version "3.7.6"
+  resolved "https://registry.yarnpkg.com/@crowdin/cli/-/cli-3.7.6.tgz#272a5417c964c28c4ceb4ab0adb31d482b1f6cf1"
+  integrity sha512-iXKPexzaave7mNadVA0nAhhdi3DsSmU/hbrt1LhpYNW6Lngp74PXQ1hShxCgflPeqpExF/ZJaptWW8qAgNpwQg==
+  dependencies:
+    shelljs "^0.8.4"
+
 "@docsearch/css@3.0.0-alpha.40":
   version "3.0.0-alpha.40"
   resolved "https://registry.yarnpkg.com/@docsearch/css/-/css-3.0.0-alpha.40.tgz#c37bd7b03f4c30a6ea7a19b87fe71880d2e8b22a"


### PR DESCRIPTION
This PR adds the necessary files and configuration in order for http://crowdin.com/ to be integrated with this repo.

Here is what needs to be done:

1) Someone with Yearn account ownership should create a new project at http://crowdin.com/
2) Change the Project ID and the crowdin token on the crowdin.yml file
3) Run `yarn upload-translations` in order to upload the files to crowdin so it can generate all desired translations placeholders
4) We need some kind of routine to run `yarn download-translations` in order to download what people have translated at the Crowdin platform

@KurogeWashu also has a point about the deploy at GH pages not working for the way that docusaurus change between translations which I'll leave it to him to comment here about it!