### PR TITLE
refactor: add bluepill remove ycontributors

### DIFF
--- a/docs/contributing/contribute.md
+++ b/docs/contributing/contribute.md
@@ -4,7 +4,7 @@
 
 ## Yearn Contributors
 
-Help build the future of finance, shape your skills, and grow the Yearn ecosystem. Before joining our community, take some time to understand the philosophy behind Yearn through the [Yearn Manifesto](https://gov.yearn.finance/t/how-we-think-about-yearn/7137).
+Help build the future of finance, shape your skills, and grow the Yearn ecosystem. Before joining our community, take some time to understand the philosophy behind Yearn through the [The Bluepill](https://yfistory.org/thebluepill) and [Yearn Manifesto](https://gov.yearn.finance/t/how-we-think-about-yearn/7137).
 
 ## How to Contribute
 
@@ -65,10 +65,6 @@ If you are looking to integrate with Yearn, please visit our [Integration Guide]
 #### Designers
 
 We invite designers, animators, artists, and more to share your skills with the Yearn ecosystem! If you're interested in creating graphics that describe Yearn's systems, creating video explainers, fixing Yearn's UI/UX, or any other combination of things — hop into the #ui-ux channel or #media-resources channels in [Discord](https://discord.gg/H8AVhpz63R).
-
-## Yearn Contributors
-
-See our wonderful list of contributors along with individual contribution stats at [yContributors.finance](https://ycontributors.finance/). Get your name added to the list by contributing to documentation, code, designs, or whatever else you're interested in!
 
 #### Creating Strategies
 


### PR DESCRIPTION
closes #184 

Removed the ycontributors section because it only made sense if the
service was still up, we can put it back if the service comes back online