### PR TITLE
remove broken strategy example

### DIFF
--- a/docs/developers/v2/getting-started.md
+++ b/docs/developers/v2/getting-started.md
@@ -25,9 +25,7 @@ This is the short version of the vetting process for a new strategy.
 1. Code the strategy using [brownie-strategy-mix](https://github.com/yearn/brownie-strategy-mix) repository
 2. Complete peer review by, at least, 2 other strategists
 3. Test in prod on [ape.tax](https://ape.tax) with real funds
-4. Create a Due Diligence document for the protocol. Follow the examples:
-   - [SNX](https://hackmd.io/0w1RZh7DSc27A9EyzlHbJQ?view)
-   - [VESPER](https://hackmd.io/@Ap_76vwNTg-vxJxbiaLMMQ/SkXEzic7O)
+4. Create a Due Diligence document for the protocol. Follow the example: [SNX](https://hackmd.io/0w1RZh7DSc27A9EyzlHbJQ?view)
 5. Get the strategy approved by the Safe Farming Committee
 6. Complete review by one internal auditor
 7. The strategy goes to prod


### PR DESCRIPTION
if anyone has a backup we could change for it, but I haven't found a history for the vesper doc that was blanked