### PR TITLE
add fantom and arbitrum deployment addresses

### DIFF
--- a/docs/developers/v2/DEPLOYMENT.md
+++ b/docs/developers/v2/DEPLOYMENT.md
@@ -293,7 +293,7 @@ healthcheck.setCheck(strategy, customHealthCheck)
 
 Custom Health Check **must** follow the interface for [custom health checks](https://github.com/yearn/yearn-vaults/blob/3bea2d8c070efeb05bc02d7d0136120bc516af4b/contracts/CommonHealthCheck.sol#L5)
 
-### Addresses
+### Ethereum Addresses
 
 | Identity               | ENS                   | Address                                    |
 | ---------------------- | --------------------- | ------------------------------------------ |
@@ -303,3 +303,23 @@ Custom Health Check **must** follow the interface for [custom health checks](htt
 | Core Dev multisig      | dev.ychad.eth         | 0x846e211e8ba920B353FB717631C015cf04061Cc9 |
 | Treasury               | treasury.ychad.eth    | 0x93A62dA5a14C80f265DAbC077fCEE437B1a0Efde |
 | Health Check           | health.ychad.eth      | 0xDDCea799fF1699e98EDF118e0629A974Df7DF012 |
+
+### Fantom Addresses
+
+| Identity               | Address                                    |
+| ---------------------- | ------------------------------------------ |
+| Registry               | 0x727fe1759430df13655ddb0731dE0D0FDE929b04 |
+| Strategist multisig    | 0x72a34AbafAB09b15E7191822A679f28E067C4a16 |
+| Governance multisig    | 0xC0E2830724C946a6748dDFE09753613cd38f6767 |
+| Treasury               | 0x89716ad7edc3be3b35695789c475f3e7a3deb12a |
+| Health Check           | 0xf13Cd6887C62B5beC145e30c38c4938c5E627fe0 |
+
+### Arbitrum Addresses
+
+| Identity               | Address                                    |
+| ---------------------- | ------------------------------------------ |
+| Registry               | 0x3199437193625DCcD6F9C9e98BDf93582200Eb1f |
+| Strategist multisig    | 0x6346282DB8323A54E840c6C772B4399C9c655C0d |
+| Governance multisig    | 0xb6bc033D34733329971B938fEf32faD7e98E56aD |
+| Treasury               | 0x1DEb47dCC9a35AD454Bf7f0fCDb03c09792C08c1 |
+| Health Check           | 0x32059ccE723b4DD15dD5cb2a5187f814e6c470bC |


### PR DESCRIPTION
adds the following to the deployment page:

# Fantom

- Governance MS: 0xC0E2830724C946a6748dDFE09753613cd38f6767
- Treasury: 0x89716ad7edc3be3b35695789c475f3e7a3deb12a
- Strategist MS: 0x72a34AbafAB09b15E7191822A679f28E067C4a16
- Registry: 0x727fe1759430df13655ddb0731dE0D0FDE929b04
- Health Check: 0xf13Cd6887C62B5beC145e30c38c4938c5E627fe0

# Arbitrum

- Governance Multisig: 0xb6bc033D34733329971B938fEf32faD7e98E56aD
- Strategist Multisig: 0x6346282DB8323A54E840c6C772B4399C9c655C0d
- Treasury: 0x1DEb47dCC9a35AD454Bf7f0fCDb03c09792C08c1
- registry: 0x3199437193625DCcD6F9C9e98BDf93582200Eb1f
- Health Check: 0x32059ccE723b4DD15dD5cb2a5187f814e6c470bC

----

### Preview

![image](https://user-images.githubusercontent.com/7863230/168681249-6c181c56-11ce-41c2-84fb-c06c3337084f.png)
