### PR TITLE
fix og image

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -23,7 +23,7 @@ module.exports = {
       disableSwitch: false,
       respectPrefersColorScheme: true,
     },
-    image: 'img/YFILogoGradient.png',
+    image: 'img/YFILogoGradient.jpg',
     metadata: [
       {
         name: 'twitter:card',


### PR DESCRIPTION
telegram preview link was showing the old logo

preview:
![image](https://user-images.githubusercontent.com/7863230/202463750-16fcb62f-f5b4-4465-bd7c-07b57a457f18.png)
