### PR TITLE
deprecate yvecrv from sidebar

### DIFF
--- a/sidebars/sidebarsGettingStarted.js
+++ b/sidebars/sidebarsGettingStarted.js
@@ -34,7 +34,6 @@ module.exports = {
         'guides/how-boost-works',
         'guides/how-to-add-a-custom-token-to-metamask',
         'guides/how-to-understand-yvault-roi',
-        'guides/how-to-understand-yveCRV',
         'guides/how-apy-works',
         'guides/how-to-understand-strategies-descriptions',
       ],


### PR DESCRIPTION
this is a suggestion, but since we dont use this product anymore I think we should remove it to not lead users to reading docs on outdated products