### PR TITLE
fix: Change docs link of the 'Vault and Strategies' section

### DIFF
--- a/docs/getting-started/products/yvaults/vaults-and-strategies.md
+++ b/docs/getting-started/products/yvaults/vaults-and-strategies.md
@@ -2,7 +2,7 @@
 
 After depositing, your funds first go to the vault contract and then are deployed to one or more strategy contracts. Guardians and strategists monitor deposits to ensure optimal returns and to be available during critical situations.
 
-**Vault and Strategies Introduction:** [What are Vaults and Strategies?](https://blog.yearn.finance/articles/marco-worms/yearn-finance-explained-what-are-vaults-and-strategies)
+**Vault and Strategies Introduction:** [What are Vaults and Strategies?](https://medium.com/iearn/yearn-finance-explained-what-are-vaults-and-strategies-96970560432)
 
 **Vault and Strategies Contracts:** [Yearn Watch](https://yearn.watch/)
 


### PR DESCRIPTION


## Description

The purpose of this PR is to correct the blog link: `What are Vaults and Strategies? `. Added to `Vault and Strategies Introduction` subsection as shown in the screenshot below. Currently the link isn't redirecting to the blog that the user is expected to consult.

<img width="1416" alt="251628164-7914bd5e-9bb7-44ce-bb76-23963f7dac90" src="https://github.com/yearn/yearn-devdocs/assets/104786213/3a09cecc-2334-4025-829b-cefb17db2b86">

## Motivation and Context

The motivation for applying this change is to improve the user experience, fix the current issue and make all links work as planned.

