### PR TITLE
Add seafood #373

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
+.markdownlint.json
+
 # Use yarn.lock
 package-lock.json
 

--- a/docs/resources/links.md
+++ b/docs/resources/links.md
@@ -32,6 +32,7 @@
 - [yVaults v2 Strategies](https://yearn.watch/)
 - [yVaults v2 Details](https://seafood.yearn.watch)
 - [Risk Dashboard](https://yearn.watch/risk)
+- [Seafood Dashboard](https://seafood.yearn.watch)
 - [Yearn Lens](https://github.com/yearn/yearn-lens)
 
 ### Statistics

--- a/docs/resources/links.md
+++ b/docs/resources/links.md
@@ -31,7 +31,7 @@
 - [Vaults at Yearn](https://vaults.yearn.fi/)
 - [yVaults v2 Strategies](https://yearn.watch/)
 - [yVaults v2 Details](https://seafood.yearn.watch)
-- [Risk Dashboard](https://yearn.watch/risk)
+- [Risk Dashboard](https://seafood.yearn.watch/risk)
 - [Seafood Dashboard](https://seafood.yearn.watch)
 - [Yearn Lens](https://github.com/yearn/yearn-lens)
 

--- a/docs/resources/links.md
+++ b/docs/resources/links.md
@@ -18,7 +18,6 @@
 - [Twitter](https://twitter.com/yearnfi)
 - [Medium](https://medium.com/iearn)
 - [Yearn Newsletter](https://yearn.substack.com/)
-- [The Vaults at Yearn](https://vaults.yearn.fi/)
 
 ### Collaborate
 
@@ -28,17 +27,14 @@
 
 ### Vaults Detail Reference
 
-- [Vaults at Yearn](https://vaults.yearn.fi/)
 - [yVaults v2 Strategies](https://yearn.watch/)
 - [yVaults v2 Details](https://seafood.yearn.watch)
 - [Risk Dashboard](https://seafood.yearn.watch/risk)
-- [Seafood Dashboard](https://seafood.yearn.watch)
 - [Yearn Lens](https://github.com/yearn/yearn-lens)
 
 ### Statistics
 
 - [Yearn Dashboard](https://yearn.vision)
-- [Yearn v2 Subgraph](https://thegraph.com/explorer/subgraph?id=0xf50b705e4eaba269dfe954f10c65bd34e6351e0c-0&view=Overview)
 - [Yearn API](https://ydaemon.yearn.fi/1/vaults/all)
 - [Yearn on Token Terminal](https://www.tokenterminal.com/terminal/projects/yearn-finance)
 

--- a/docs/resources/risks/risk-score.md
+++ b/docs/resources/risks/risk-score.md
@@ -12,18 +12,18 @@ Different risk scores for all V2 vaults can be viewed on the [Seafood](https://s
 
 Risk for different strategies is quantified using a 1-5 point system developed by Yearn's strategy deployment process. The higher the risk score number, the more risky the strategy is. The risk assessment evaluates eight dimensions:
 
-* [Risk Scores](#risk-scores)
-  * [Strategy Risk Score](#strategy-risk-score)
-    * [Audit](#audit)
-    * [Code Review](#code-review)
-    * [Complexity](#complexity)
-    * [Longevity](#longevity)
-    * [Protocol Safety](#protocol-safety)
-    * [Team Knowledge](#team-knowledge)
-    * [Testing Score](#testing-score)
-    * [TVL Impact](#tvl-impact)
-  * [Vault Risk Score Proposal](#vault-risk-score-proposal)
-  * [Overall Risk Score Proposal](#overall-risk-score-proposal)
+- [Risk Scores](#risk-scores)
+  - [Strategy Risk Score](#strategy-risk-score)
+    - [Audit](#audit)
+    - [Code Review](#code-review)
+    - [Complexity](#complexity)
+    - [Longevity](#longevity)
+    - [Protocol Safety](#protocol-safety)
+    - [Team Knowledge](#team-knowledge)
+    - [Testing Score](#testing-score)
+    - [TVL Impact](#tvl-impact)
+  - [Vault Risk Score Proposal](#vault-risk-score-proposal)
+  - [Overall Risk Score Proposal](#overall-risk-score-proposal)
 
 This risk framework is an ongoing process to ensure the security of Yearn strategies. Yearn recognized that, due to its unique approach to deploying strategies, it could not rely on a traditional waterfall process (heavy analysis and design, testing, multiple audits before release, etc.) to deploy contracts. Strategies are deployed and capped by their risk score. As we reduce the risk in any of the eight dimensions, the strategy can grow its TVL. This system allows Yearn to compare the risk score of two strategies and prioritize risk mitigation and preventive actions, such as forming a committee to spread knowledge on the code, getting more audits, migrating current code to improved versions of the strategy, etc.
 

--- a/docs/resources/risks/risk-score.md
+++ b/docs/resources/risks/risk-score.md
@@ -6,25 +6,27 @@ Yearn works with risk scores to quantify and assess the amount of risk of each s
 * [**Vault Risk Score Proposal**](#vault-risk-score-proposal) aggregates all strategy scores for a vault, averaging by TVL **(this is in draft stage)**
 * [**Overall Risk Score Proposal**](#overall-risk-score-proposal) aggregates strategy/vault scores into overall scores **(this is in draft stage)**
 
+Different risk scores for all V2 vaults can be viewed on the [Seafood](https://seafood.yearn.watch/risk) Dashboard.
+
 ## Strategy Risk Score
 
 Risk for different strategies is quantified using a 1-5 point system developed by Yearn's strategy deployment process. The higher the risk score number, the more risky the strategy is. The risk assessment evaluates eight dimensions:
 
-- [Risk Scores](#risk-scores)
-  - [Strategy Risk Score](#strategy-risk-score)
-    - [Audit](#audit)
-    - [Code Review](#code-review)
-    - [Complexity](#complexity)
-    - [Longevity](#longevity)
-    - [Protocol Safety](#protocol-safety)
-    - [Team Knowledge](#team-knowledge)
-    - [Testing Score](#testing-score)
-    - [TVL Impact](#tvl-impact)
-  - [Vault Risk Score Proposal](#vault-risk-score-proposal)
-  - [Overall Risk Score Proposal](#overall-risk-score-proposal)
+* [Risk Scores](#risk-scores)
+  * [Strategy Risk Score](#strategy-risk-score)
+    * [Audit](#audit)
+    * [Code Review](#code-review)
+    * [Complexity](#complexity)
+    * [Longevity](#longevity)
+    * [Protocol Safety](#protocol-safety)
+    * [Team Knowledge](#team-knowledge)
+    * [Testing Score](#testing-score)
+    * [TVL Impact](#tvl-impact)
+  * [Vault Risk Score Proposal](#vault-risk-score-proposal)
+  * [Overall Risk Score Proposal](#overall-risk-score-proposal)
 
-This risk framework is an ongoing process to ensure the security of Yearn strategies. Yearn recognized that, due to its unique approach to deploying strategies, it could not rely on a traditional waterfall process (heavy analysis and design, testing, multiple audits before release, etc.) to deploy contracts. Strategies are deployed and capped by their risk score. As we reduce the risk in any of the eight dimensions, the strategy can grow its TVL. This system allows Yearn to compare the risk score of two strategies and prioritize risk mitigation and preventive actions, such as forming a committee to spread knowledge on the code, getting more audits, migrating current code to improved versions of the strategy, etc. 
- 
+This risk framework is an ongoing process to ensure the security of Yearn strategies. Yearn recognized that, due to its unique approach to deploying strategies, it could not rely on a traditional waterfall process (heavy analysis and design, testing, multiple audits before release, etc.) to deploy contracts. Strategies are deployed and capped by their risk score. As we reduce the risk in any of the eight dimensions, the strategy can grow its TVL. This system allows Yearn to compare the risk score of two strategies and prioritize risk mitigation and preventive actions, such as forming a committee to spread knowledge on the code, getting more audits, migrating current code to improved versions of the strategy, etc.
+
 The current version of the risk score system works for Yearn's current needs, but we are always looking to improve and expand it to the vaults. We want to provide our users with a better understanding of what is happening behind the scenes in the vaults. The development of vault risk scoring is still in progress!
 
 ### Audit
@@ -159,7 +161,7 @@ How long the strategy has been running live on yearn.fi:
 
 ### Protocol Safety
 
-Protocol Safety evaluates the resilience of the protocol the strategy uses. It takes into account the safety measures given the current DeFi security standards, based on our internal assessments and due diligence compared to the top projects in DeFI. This includes multisig health, decentralization, bounty programs, audits, etc. 
+Protocol Safety evaluates the resilience of the protocol the strategy uses. It takes into account the safety measures given the current DeFi security standards, based on our internal assessments and due diligence compared to the top projects in DeFI. This includes multisig health, decentralization, bounty programs, audits, etc.
 
 We hope to improve this dimension with the help of the DeFI community to potentially use a standard scoring system that is widely accepted in the ecosystem to replace our current scoring table:
 
@@ -252,10 +254,9 @@ Testing score is a metric of how much of the codebase for the strategy has been 
   </tr>
 </table>
 
-
 ### TVL Impact
 
-The TVL (total value locked) metric measures how to allocate to new riskier strategies without having a catastrophic event in case of a hack or issue. The lower the impact, the more likely Yearn’s treasury can recover from an incident. The TVL is measured in USD and grows dynamically based on strategies allocations onchain. Through [yearn.watch](https://yearn.watch/), we keep track of the TVL and risk score to make fund allocation decisions and mitigations if a strategy group has fallen into the “red” high-risk zone:
+The TVL (total value locked) metric measures how to allocate to new riskier strategies without having a catastrophic event in case of a hack or issue. The lower the impact, the more likely Yearn’s treasury can recover from an incident. The TVL is measured in USD and grows dynamically based on strategies allocations onchain. Through [yearn.watch](https://yearn.watch/) and [seafood](https://seafood.yearn.watch/risk), we keep track of the TVL and risk score to make fund allocation decisions and mitigations if a strategy group has fallen into the “red” high-risk zone:
 
 <table>
   <tr>

--- a/docs/resources/risks/risk-score.md
+++ b/docs/resources/risks/risk-score.md
@@ -256,7 +256,7 @@ Testing score is a metric of how much of the codebase for the strategy has been 
 
 ### TVL Impact
 
-The TVL (total value locked) metric measures how to allocate to new riskier strategies without having a catastrophic event in case of a hack or issue. The lower the impact, the more likely Yearn’s treasury can recover from an incident. The TVL is measured in USD and grows dynamically based on strategies allocations onchain. Through [yearn.watch](https://yearn.watch/) and [seafood](https://seafood.yearn.watch/risk), we keep track of the TVL and risk score to make fund allocation decisions and mitigations if a strategy group has fallen into the “red” high-risk zone:
+The TVL (total value locked) metric measures how to allocate to new riskier strategies without having a catastrophic event in case of a hack or issue. The lower the impact, the more likely Yearn’s treasury can recover from an incident. The TVL is measured in USD and grows dynamically based on strategies allocations onchain. Through [seafood](https://seafood.yearn.watch/risk) we keep track of the TVL and risk score to make fund allocation decisions and mitigations if a strategy group has fallen into the “red” high-risk zone:
 
 <table>
   <tr>


### PR DESCRIPTION
- Added link to seafood in `links.md` under "vault detail reference" section
- Added line near the top with link to seafood to view risk scores.
- Added link to https://seafood.yearn.watch/risk in TVL impact section of `risk.md` in addition to the existing yearnwatch link.
- Some automatic formatting changes (like the other issues I just submitted)

Question:
Is there a linting config file in the repo that I can use to disable certain linter items? In the meantime I added my own and updated the .gitignore so it doesn't get added.