### PR TITLE
add veCRV info links

### DIFF
--- a/docs/getting-started/products/ylockers/overview.md
+++ b/docs/getting-started/products/ylockers/overview.md
@@ -6,7 +6,7 @@ The new Ylockers ecosystem has rolled out as of June 6th, 2024 with the launch o
 
 :::
 
-yLockers are a category of assets built by Yearn designed to tokenize locked governance positions in external DeFi protocols. This asset type is often called a "Liquid Locker".
+yLockers are a category of assets built by Yearn designed to tokenize locked governance positions in external DeFi protocols based on [Curve's vote escrow (ve) model](https://resources.curve.fi/crv-token/vecrv/). This asset type is often called a "Liquid Locker".
 
 To achieve this, Yearn has deployed a system of smart contracts that allows users to permissionlessly max-lock their governance tokens to Yearn in exchange for a yLocker token (e.g., yCRV, yPRISMA, etc.) at a rate of 1:1.
 

--- a/docs/getting-started/products/ylockers/ycrv/overview.md
+++ b/docs/getting-started/products/ylockers/ycrv/overview.md
@@ -3,7 +3,7 @@
 
 ## What is yCRV?
 
-yCRV is Yearn's veCRV yLocker product. It is designed to tokenize the different benefits of a veCRV position in a simple, user-friendly way. Let's review the basics of liquid locker tokens like yCRV:
+yCRV is Yearn's veCRV yLocker product. It is designed to tokenize the different benefits of a [veCRV position](https://resources.curve.fi/crv-token/vecrv/) in a simple, user-friendly way. Let's review the basics of liquid locker tokens like yCRV:
 
 - 1 yCRV represents 1 veCRV max-locked to Yearn
 - They are not redeemable for the underlying locked CRV

--- a/docs/getting-started/products/ylockers/ycrv/ycrv-faq.md
+++ b/docs/getting-started/products/ylockers/ycrv/ycrv-faq.md
@@ -1,5 +1,6 @@
 # yCRV FAQ
 
+<!-- markdownlint-disable MD001 -->
 ### When will yCRV launch?
 
 Contracts are live, you can find relevant addresses [here](/getting-started/products/ylockers/ycrv/overview#addresses).
@@ -16,7 +17,7 @@ yCRV can be purchased through the following platforms:
 
 YearnBoostedStaker (YBS) is a new contract from Yearn that allows yCRV holders to earn rewards in stable-coins (crvUSD). It is a new option that yCRV holders can choose from in addition to the traditional auto-compounding version of yCRV (yvyCRV). You can read more about how each option works [here](../overview.md#ylocker-products)
 
-## Should I stake my yCRV directly or auto-compound it in the vault?
+### Should I stake my yCRV directly or auto-compound it in the vault?
 
 That's totally up to you and depends on your personal situation and preferences. Here are a few things to consider:
 
@@ -33,28 +34,28 @@ That's totally up to you and depends on your personal situation and preferences.
   * Direct stakers do not receive a receipt token in their wallet.
   * Vault depositors receive back a yv-yCRV token into their wallet which has the potential to be accepted as collateral across DeFi.
 
-## Can yCRV users vote with their yCRV?
+### Can yCRV users vote with their yCRV?
 
 No. User voting is not part of the yLockers system, instead...
 
 * Gauge voting is automated to optimize for the maximum weekly vote incentive yield.
 * Governance voting is handled by a team of core contributors on behalf of veYFI holders.
 
-## Why is the yCRV peg currently below 1:1?
+### Why is the yCRV peg currently below 1:1?
 
 It is normal for a yToken such as yCRV (or any liquid locker token) to trade at a discount to the governance token it is built upon. The strength of the peg is dependent on the supply and demand of each yToken.
 
 Each yLocker has been designed to create an attractive yToken that offers value to users and provides incentives to attract liquidity. However, we cannot control the market price of our yTokens.
 
-## What is yvcrvUSD?
+### What is yvcrvUSD?
 
 yvcrvUSD is a Yearn V3 vault that allows yield to auto-compound.
 
-## What are the fees associated with yCRV?
+### What are the fees associated with yCRV?
 
 When you stake yCRV, a 10% performance fee is applied. Yield accumulates in the receiver contract throughout the week. The yield is distributed once per week, at which point 10% is sent to the Yearn treasury.
 
-## Where does the yield come from and how does it flow?
+### Where does the yield come from and how does it flow?
 
 The yield for yCRV stakers comes from two main sources:
 

--- a/docs/getting-started/products/ylockers/yprisma/yprisma-faq.md
+++ b/docs/getting-started/products/ylockers/yprisma/yprisma-faq.md
@@ -1,6 +1,7 @@
 # yPRISMA FAQ
 
-## Where can I buy yPRISMA?
+<!-- markdownlint-disable MD001 -->
+### Where can I buy yPRISMA?
 
 yPRISMA can be purchased through the following platforms:
 
@@ -8,7 +9,7 @@ yPRISMA can be purchased through the following platforms:
 * [Curve Finance](https://curve.fi/#/ethereum/swap?from=0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee&to=0xe3668873d944e4a949da05fc8bde419eff543882) - The primary liquidity source for yPRISMA
 * [CowSwap](https://swap.cow.fi/#/1/swap/ETH/YPRISMA) - DEX aggregators like CowSwap should also work well
 
-## Should I stake my yPRISMA directly or auto-compound it in the vault?
+### Should I stake my yPRISMA directly or auto-compound it in the vault?
 
 That's totally up to you and depends on your personal situation and preferences. Here are a few things to consider:
 
@@ -25,28 +26,28 @@ That's totally up to you and depends on your personal situation and preferences.
   * Direct stakers do not receive a receipt token in their wallet.
   * Vault depositors receive back a yv-yPRISMA token into their wallet which has the potential to be accepted as collateral across DeFi.
 
-## Can yPRISMA users vote with their yPRISMA?
+### Can yPRISMA users vote with their yPRISMA?
 
 No. User voting is not part of the yLockers system, instead...
 
 * Gauge voting is automated to optimize for the maximum weekly vote incentive yield.
 * Governance voting is handled by a team of core contributors on behalf of veYFI holders.
 
-## Why is the yPRISMA peg currently below 1:1?
+### Why is the yPRISMA peg currently below 1:1?
 
 It is normal for a yToken such as yPRISMA (or any liquid locker token) to trade at a discount to the governance token it is built upon. The strength of the peg is dependent on the supply and demand of each yToken.
 
 Each yLocker has been designed to create an attractive yToken that offers value to users and provides incentives to attract liquidity. However, we cannot control the market price of our yTokens.
 
-## What is yvmkUSD-A?
+### What is yvmkUSD-A?
 
 yvmkUSD-A is a Yearn V3 vault that allows yield to auto-compound. Currently, there is no active strategy for compounding, but a strategy is nearly completed and will undergo reviews soon.
 
-## What are the fees associated with yPRISMA?
+### What are the fees associated with yPRISMA?
 
 When you stake yPRISMA, a 10% performance fee is applied. Yield accumulates in the receiver contract throughout the week. The yield is distributed once per week, at which point 10% is sent to the Yearn treasury.
 
-## Where does the yield come from and how does it flow?
+### Where does the yield come from and how does it flow?
 
 The yield for yPRISMA stakers comes from two main sources:
 


### PR DESCRIPTION
smol change: add link to veCRV documentation in yCRV and yLocker docs as we never really explain how ve-tokenomics work.