### PR TITLE
Feat: add branch display to dev builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ yarn-error.log*
 
 .markdownlint.json
 
+.branch-name
+
 # Use yarn.lock
 package-lock.json
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -4,6 +4,9 @@ import math from 'remark-math'
 import katex from 'rehype-katex'
 import { themes as prismThemes } from 'prism-react-renderer'
 
+const branchName = process.env.BRANCH_NAME || 'unknown'
+const isDev = process.env.IS_DEV === 'true'
+
 export default {
   title: 'Yearn Docs',
   tagline: 'DeFi made simple',
@@ -16,6 +19,10 @@ export default {
   projectName: 'yearn-devdocs', // Usually your repo name.
   markdown: {
     mermaid: true,
+  },
+  customFields: {
+    branchName,
+    isDev,
   },
   themes: ['@docusaurus/theme-mermaid'],
   themeConfig: {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.4.3",
   "scripts": {
     "docusaurus": "docusaurus",
-    "start": "docusaurus start",
+    "get-branch-name": "git rev-parse --abbrev-ref HEAD > .branch-name",
+    "start": "yarn get-branch-name && BRANCH_NAME=$(cat .branch-name) IS_DEV=true docusaurus start",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",

--- a/src/theme/Layout/index.js
+++ b/src/theme/Layout/index.js
@@ -1,0 +1,27 @@
+import React from 'react'
+import Layout from '@theme-original/Layout'
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext'
+
+export default function LayoutWrapper(props) {
+  const { siteConfig } = useDocusaurusContext()
+  const { branchName, isDev } = siteConfig.customFields
+
+  return (
+    <>
+      {isDev && (
+        <div
+          style={{
+            position: 'fixed',
+            top: 0,
+            right: 0,
+            background: 'yellow',
+            padding: '5px',
+          }}
+        >
+          Branch: {branchName}
+        </div>
+      )}
+      <Layout {...props} />
+    </>
+  )
+}

--- a/src/theme/Layout/index.js
+++ b/src/theme/Layout/index.js
@@ -18,7 +18,7 @@ export default function LayoutWrapper(props) {
             padding: '5px',
           }}
         >
-          Branch: {branchName}
+          {branchName}
         </div>
       )}
       <Layout {...props} />


### PR DESCRIPTION
This PR adds an element to the top right corner of the screen showing what branch is being served when running dev builds. It runs when using `yarn start`. This is intended as a useful tool when actively working in multiple branches to keep track of what is what.

There should be no change to the production version of the site.