### PR TITLE
Typo Update working-on-docs.md

### DIFF
--- a/docs/contributing/documentation/working-on-docs.md
+++ b/docs/contributing/documentation/working-on-docs.md
@@ -4,7 +4,7 @@
 
 Yearn's documentation repository is hosted on GitHub in order to foster and encourage open source collaboration.
 
-_Note for translators: Non-english docs are store in separate branches. When merging your changes, direct your pull request to the corresponding branch_
+_Note for translators: Non-english docs are stored in separate branches. When merging your changes, direct your pull request to the corresponding branch_
 
 ## Working with HackMD
 


### PR DESCRIPTION
<img width="1153" alt="Снимок экрана 2024-11-11 в 20 07 12" src="https://github.com/user-attachments/assets/b736db21-5975-43a8-97d5-55494a40470a">

"are store" corrected to "are store**d**".