### PR TITLE
Grammar and Clarity Improvements

### DIFF
--- a/docs/resources/deprecated/ygift.md
+++ b/docs/resources/deprecated/ygift.md
@@ -15,7 +15,7 @@ Anyone can create and send a yGift. It is possible to add an image or mp4 video,
 
 ![](https://i.imgur.com/DtrbCtH.png)
 
-4. Add a receiver **ETH or ENS address**. Make sure it is the correct Ethereum wallet address, or the yGift will be lost
+4. Add a receiver **ETH or ENS addresses**. Make sure it is the correct Ethereum wallet address, or the yGift will be lost
 5. In case you want to add funds to your yGift, choose the token and amount. **Adding funds is optional**
 6. Choose a name and write a nice message for your yGift
 7. **Locking period**: Optionally set a period of days to lock tokens added to the yGift when you create it. You may send the yGift immediately and although it will be available to the recipient, **the tokens will be locked until this period ends**
@@ -32,7 +32,7 @@ After a yGift has been sent, people can add more funds to it by tipping it! Are 
 
 ![](https://i.imgur.com/7crWB2h.png)
 
-You can only tip a yGift on the **previous chosen token**. If the yGift was minted with yUSD being the token (even if initial amount was set to 0), then the tips have to be in yUSD.
+You can only tip a yGift on the **previously chosen token**. If the yGift was minted with yUSD being the token (even if initial amount was set to 0), then the tips have to be in yUSD.
 
 Tips are always **immediately available** and not subject to locking or vesting.
 

--- a/docs/resources/deprecated/ytrade.md
+++ b/docs/resources/deprecated/ytrade.md
@@ -10,4 +10,4 @@ Status: Not recommended for retail use
 
 This is a unique product in the market and it enables users to conduct arbitrage trades whenever certain stablecoins are not pegged exactly to $1. For example: DAI is intended to be pegged at $1, however, occasionally in the past it has traded at $1.05. A user can deposit a stablecoin as collateral and borrow up to 1000x of his or her collateral, receive DAI, sell it for $1.05 each, use the proceeds to buy back the amount of DAI they borrowed and profit the difference.
 
-This has significant implication in the broader DeFi space as stablecoins are frequently off their pegs, but some traders don’t possess sufficient capital to conduct profitable arbitrage trades.
+This has significant implications in the broader DeFi space as stablecoins are frequently off their pegs, but some traders don’t possess sufficient capital to conduct profitable arbitrage trades.

--- a/docs/resources/faq.md
+++ b/docs/resources/faq.md
@@ -32,7 +32,7 @@
 
 #### When do I realize profits from a vault?
 
-- Your profits [are compounded](https://docs.yearn.fi/getting-started/using-yearn#tools-to-track-your-funds) into the vault token overtime, which can be withdrawn for your principal plus profit.
+- Your profits [are compounded](https://docs.yearn.fi/getting-started/using-yearn#tools-to-track-your-funds) into the vault token over time, which can be withdrawn for your principal plus profit.
 
 #### How is vault growth calculated?
 
@@ -121,7 +121,7 @@
 
 #### I'm getting an error that says "ALERT: Transaction Error. Exception thrown in contract code." What does that mean?
 
-- There may be a bug in the contract that you are interacting with. bring this up with the team of [Discord](https://discord.gg/yearn).
+- There may be a bug in the contract that you are interacting with. bring this up with the team on [Discord](https://discord.gg/yearn).
 
 #### I paid gas for a deposit, but it didn't go through, why is that?
 


### PR DESCRIPTION
Changed "ETH or ENS address" to "ETH or ENS addresses" for plural agreement.
Updated "previous chosen token" to "previously chosen token" for correct adverb usage.
Corrected "significant implication" to "significant implications" for plural form.
Fixed "overtime" to "over time" for correct phrasing.
Adjusted "bring this up with the team of Discord" to "bring this up with the team on Discord" for correct preposition use.