### PR TITLE
fix: typos in documentation files

### DIFF
--- a/docs/contributing/governance/veyfi.md
+++ b/docs/contributing/governance/veyfi.md
@@ -8,7 +8,7 @@ veYFI incorporates [YIP-56: Buyback and Build](https://gov.yearn.fi/t/yip-56-buy
 - YFI can be locked into veYFI, which is non-transferable.
 - Lock duration can be decided on deposit: from 1 week to 4 years.
   - You can actually lock up to 10 years, but anything above 4 years doesn’t give you more veYFI. This way you don't have to relock every week. If you set it to longer than 4 years, you can always reset it to 4 years so it starts decaying.
-- A user must have a veYFI lock earn boosted rewards. No lock leads to no boosted rewards. A Maximum lock, continuously renewed, maximizes rewards.
+- A user must have a veYFI lock to earn boosted rewards. No lock leads to no boosted rewards. A Maximum lock, continuously renewed, maximizes rewards.
   - Just like with Curve, even without a veYFI lock, you can still deposit into a vault and stake the vault token into a gauge which will give you the base boost. With the minimum boost, you get to keep 10% of the dYFI you farm. The other 90% goes to veYFI lockers.
 - It’s possible to exit the lock early, in exchange for paying a penalty that gets allocated to the other veYFI holders.
 - The penalty is up to 75% locked amount and decays over time:

--- a/docs/developers/v2/ledger-plugin.md
+++ b/docs/developers/v2/ledger-plugin.md
@@ -4,7 +4,7 @@ The plugin allows you to interact with the Yearn website directly from your Ledg
 
 Every addition, deletion, and modification of a Vault should be reflected in this plugin and will require a verification by the Ledger's Team based on a new pull request on the [LedgerHQ/app-plugin-yearn](https://github.com/LedgerHQ/app-plugin-yearn) repository.
 
-This guide provides an easy step by step to add a new vault.
+This guide provides an easy step-by-step to add a new vault.
 
 ## Setup your environment 
 

--- a/docs/developers/v2/yswaps.md
+++ b/docs/developers/v2/yswaps.md
@@ -12,7 +12,7 @@ ySwaps is used to **abstract** the token trading logic from the strategies harve
 ## Glossary
 - `sms`: Strategists multisig
 - `tokenIn`:  Token we have and we want to trade/swap
-- `toeknOut`: Token we want to obtain on the swap
+- `tokenOut`: Token we want to obtain on the swap
 - `hopToken`: Token we use as a middle step between tokenIn and tokenOut
 - `tf`: Trade Factory
 
@@ -34,7 +34,7 @@ Contracts in charge of making the swaps (uniswap, balancer, sushiswap, solidly a
 
 #### Single swapper
 
-Uniswap, balancer, sushiswap, etc. These are straighforward contracts that will make a simple swap on these dexes (`token A` to `token B`). It is also worth to mention that these swappers take care of few extra stuff like: `approval needed to make the swap`, `transfering final tokens to strategy if needed`.
+Uniswap, balancer, sushiswap, etc. These are straightforward contracts that will make a simple swap on these dexes (`token A` to `token B`). It is also worth to mention that these swappers take care of few extra stuff like: `approval needed to make the swap`, `transfering final tokens to strategy if needed`.
 
 #### Multicall swapper
 


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected "lock earn" to "lock to earn".
Corrected "toeknOut" to "tokenOut".
Corrected "straighforward" to "straightforward".
Corrected "step by step" to "step-by-step".

Please review the changes and let me know if any additional changes are needed.