### PR TITLE
Fix Possessive Apostrophe in "Contributor's" to "Contributors'"

### DIFF
--- a/docs/resources/deprecated/ygift.md
+++ b/docs/resources/deprecated/ygift.md
@@ -25,7 +25,7 @@ Anyone can create and send a yGift. It is possible to add an image or mp4 video,
 
 ## How to Tip a yGift
 
-After a yGift has been sent, people can add more funds to it by tipping it! Are you feeling generous? Tip contributor's gift and share some love!
+After a yGift has been sent, people can add more funds to it by tipping it! Are you feeling generous? Tip contributors gift and share some love!
 
 1. Access the page of the yGift you want to tip;
 2. Click on "tip". Set amount and write a nice message


### PR DESCRIPTION
The error "contributor's" instead of "contributors'" involves the incorrect use of the apostrophe to indicate possession. In this context, "contributors" (plural) should be used with an apostrophe after the "s" to show ownership, i.e., "contributors' gift" (gift from multiple contributors). This is important because the incorrect apostrophe usage can affect the readability and professionalism of the text, creating an impression of carelessness.