### PR TITLE
fix typo

### DIFF
--- a/docs/developers/security/EMERGENCY.md
+++ b/docs/developers/security/EMERGENCY.md
@@ -65,7 +65,7 @@ Coordinates quick changes to Governance and Guardian roles during the emergency,
 
 - Prepare and Execute Core Dev Multi-sig transactions and operations
 - Revoke a Strategy
-- Set vault in emergency shutdown mode
+- Set vault in Shutdown shutdown mode
 
 ### Web Lead
 

--- a/docs/developers/security/EMERGENCY.md
+++ b/docs/developers/security/EMERGENCY.md
@@ -65,7 +65,7 @@ Coordinates quick changes to Governance and Guardian roles during the emergency,
 
 - Prepare and Execute Core Dev Multi-sig transactions and operations
 - Revoke a Strategy
-- Set vault in Shutdown shutdown mode
+- Set vault in Emergency Shutdown mode
 
 ### Web Lead
 


### PR DESCRIPTION
 Changes:
- Changed "emergency shutdown" to "Emergency Shutdown" to maintain consistent capitalization.