### PR TITLE
Fix: AddressCheck action

### DIFF
--- a/.github/workflows/addressChecks.yml
+++ b/.github/workflows/addressChecks.yml
@@ -52,13 +52,10 @@ jobs:
                 echo "- $CHECK" >> issue_body.md
             done
             echo "The addresses shown above should be the updated, correct addresses. Please review and change the values in \`src/ethereum/constants.ts\`." >> issue_body.md
+            echo "" >> issue_body.md
+            echo "Updated fetchedAddressData.json content:" >> issue_body.md
+            cat scripts/fetchedAddressData.json >> issue_body.md
           fi
-
-      - name: Commit and push changes
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: 'Update data from daily check'
-          file_pattern: scripts/fetchedAddressData.json
 
       - name: Create an issue if checks failed
         if: env.all_checks_passed != 'true'

--- a/scripts/fetchedAddressData.json
+++ b/scripts/fetchedAddressData.json
@@ -1,5 +1,5 @@
 {
-  "timeLastChecked": 1732226783,
+  "timeLastChecked": 1734048600,
   "addressesData": {
     "topLevel": {
       "v3ProtocolAddressProvider": "0x775F09d6f3c8D2182DFA8bce8628acf51105653c",

--- a/scripts/fetchedAddressData.json
+++ b/scripts/fetchedAddressData.json
@@ -1,5 +1,5 @@
 {
-  "timeLastChecked": 1734134988,
+  "timeLastChecked": 1734221450,
   "addressesData": {
     "topLevel": {
       "v3ProtocolAddressProvider": "0x775F09d6f3c8D2182DFA8bce8628acf51105653c",

--- a/scripts/fetchedAddressData.json
+++ b/scripts/fetchedAddressData.json
@@ -1,5 +1,5 @@
 {
-  "timeLastChecked": 1734048600,
+  "timeLastChecked": 1734134988,
   "addressesData": {
     "topLevel": {
       "v3ProtocolAddressProvider": "0x775F09d6f3c8D2182DFA8bce8628acf51105653c",

--- a/scripts/fetchedAddressData.json
+++ b/scripts/fetchedAddressData.json
@@ -1,5 +1,5 @@
 {
-  "timeLastChecked": 1734221450,
+  "timeLastChecked": 1734307828,
   "addressesData": {
     "topLevel": {
       "v3ProtocolAddressProvider": "0x775F09d6f3c8D2182DFA8bce8628acf51105653c",


### PR DESCRIPTION
Action was failing to push to the master branch due to branch protections. The fix removes the push step and instead includes the output in the issue so it can be updated manually.