### PR TITLE
fix: remove dead ydaemon docs link

### DIFF
--- a/docs/developers/data-services/yearn-data.md
+++ b/docs/developers/data-services/yearn-data.md
@@ -8,7 +8,6 @@ yDaemon is a RESTful API that hydrates subgraph responses with more data, like A
 
 - **Live API:** https://ydaemon.yearn.fi/
 - **Source:** https://github.com/yearn/ydaemon
-- **Docs:** https://ydaemon.yearn.farm/docs/intro
 - **Guide:** https://medium.com/iearn/ydaemon-one-api-to-unify-all-yearn-data-4fc74dc9a33b
 
 ## Kong


### PR DESCRIPTION
yDaemon docs are ded. Need to bring them back but for now will just kill the link.