### PR TITLE
fix: update dev build flow to check addresses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ yarn-error.log*
 
 .branch-name
 .github/copilot-instructions.md
+all_checks_passed.txt
 
 # Use yarn.lock
 package-lock.json

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "get-branch-name": "git rev-parse --abbrev-ref HEAD > .branch-name",
-    "start": "yarn get-branch-name && BRANCH_NAME=$(cat .branch-name) IS_DEV=true docusaurus start",
+    "start": "yarn runAddressCheck && yarn get-branch-name && BRANCH_NAME=$(cat .branch-name) IS_DEV=true docusaurus start",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "docusaurus": "docusaurus",
     "get-branch-name": "git rev-parse --abbrev-ref HEAD > .branch-name",
     "start": "yarn runAddressCheck && yarn get-branch-name && BRANCH_NAME=$(cat .branch-name) IS_DEV=true docusaurus start",
-    "build": "docusaurus build",
+    "build": "yarn runAddressCheck && docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",

--- a/scripts/fetchedAddressData.json
+++ b/scripts/fetchedAddressData.json
@@ -1,5 +1,5 @@
 {
-  "timeLastChecked": 1738956876,
+  "timeLastChecked": 1741647140,
   "addressesData": {
     "v3ContractAddresses": {
       "topLevel": {
@@ -80,11 +80,11 @@
     "failedChecks": [],
     "v3Checks": {
       "topLevel": {
-        "v3ProtocolAddressProviderCheck": {},
+        "v3ProtocolAddressProviderCheck": true,
         "v3ProtocolAddressProviderENSCheck": true,
-        "v3ReleaseRegistryCheck": {},
+        "v3ReleaseRegistryCheck": true,
         "v3ReleaseRegistryENSCheck": true,
-        "v3RoleManagerCheck": {},
+        "v3RoleManagerCheck": true,
         "v3RoleManagerENSCheck": true
       },
       "protocolPeriphery": {


### PR DESCRIPTION
The contract address checks are being run nightly but the json that the on-page validation components read from are not. I have added a step to the `yarn start` and `yarn build` commands that runs the script to check contract addresses. This will assure that anytime a new commit is pushed to the repo from someone building the site, it will have the most updated contracts and will reflect that on the timestamp.