### PR TITLE
fix: remove address check from build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ This command starts a local development server and opens up a browser window. Mo
 yarn start
 ```
 
-Running `yarn start` will also run a script that checks the validity of smart contract addresses in the docs against a local constants file. This runs on every dev run as a way to keep the checks updated and the information about them on the site current (all PRs will include an update to last check time). If you want to run `yarn start` without the `runAddressChecks` script running you can run `yarn start-no-check`
+Running `yarn start` will also run a script that checks the validity of smart contract addresses in the docs against a local constants file. This runs on every dev run as a way to keep the checks updated and the information about them on the site current (all PRs will include an update to last check time). If you want to run `yarn start` without the `runAddressChecks` script running you can run `yarn start-no-check`.
 
 ## Build
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ This command starts a local development server and opens up a browser window. Mo
 yarn start
 ```
 
+Running `yarn start` will also run a script that checks the validity of smart contract addresses in the docs against a local constants file. This runs on every dev run as a way to keep the checks updated and the information about them on the site current (all PRs will include an update to last check time). If you want to run `yarn start` without the `runAddressChecks` script running you can run `yarn start-no-check`
+
 ## Build
 
 This command generates static content into the `build` directory and can be served using any static content hosting service.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "docusaurus": "docusaurus",
     "get-branch-name": "git rev-parse --abbrev-ref HEAD > .branch-name",
     "start": "yarn runAddressCheck && yarn get-branch-name && BRANCH_NAME=$(cat .branch-name) IS_DEV=true docusaurus start",
+    "start-no-check": "yarn get-branch-name && BRANCH_NAME=$(cat .branch-name) IS_DEV=true docusaurus start",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "docusaurus": "docusaurus",
     "get-branch-name": "git rev-parse --abbrev-ref HEAD > .branch-name",
     "start": "yarn runAddressCheck && yarn get-branch-name && BRANCH_NAME=$(cat .branch-name) IS_DEV=true docusaurus start",
-    "build": "yarn runAddressCheck && docusaurus build",
+    "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",


### PR DESCRIPTION
I added a command to run the `addressCheck` script in the yarn build command in #532. This causes problems when building in github workflows if I don't pass the alchemy api key to the workflow step. I considered a few options to fix:

1. Add alchemy API key to the needed step.
2. Create additional build option that doesn't have script call and use that in workflows.
3. Remove script call in build step

Looking at the workflows, I am already running the script later most of the time. I added the script call to the `yarn start` command in order to make sure that any PR I made would include an updated check on the contracts to try to keep checks up to date. I don't use the build command often so option 1 seems unnecessary and adds complexity. likewise for option 2. So I will remove the script call and add documentation about why it is in the `yarn start` command.