### PR TITLE
chore: add warning to roleManager deployment instructions

### DIFF
--- a/docs/developers/v3/vault_management.md
+++ b/docs/developers/v3/vault_management.md
@@ -29,6 +29,12 @@ You will only need three variables.
 2. `governance` : The main address to be in control of the vaults and RoleManager contract. This should be a fully trusted address.
 3. `management` :  Secondary address to manage lower risk more day to day needs of the vault such as debt allocations.
 
+:::warning
+
+Make sure your `governance` and `management` addresses are NOT the same address as this will prevent you from adding strategies.
+
+:::
+
 ```solidity
 projectName = "Project Name"     // Name of your project.
 governance = address(0x69)      // Address to be in charge of the project.


### PR DESCRIPTION
Add warning to prevent someone deploying the RoleManager from adding the same address as `governance` and `management`

![image](https://github.com/user-attachments/assets/f9176dff-34df-4cf1-a065-70d43b3d4647)
